### PR TITLE
Fix Race Conditions Refactor

### DIFF
--- a/src/main/scala/kinesis/mock/api/DecreaseStreamRetentionPeriodRequest.scala
+++ b/src/main/scala/kinesis/mock/api/DecreaseStreamRetentionPeriodRequest.scala
@@ -4,7 +4,8 @@ package api
 import scala.concurrent.duration._
 
 import cats.data.Validated._
-import cats.data._
+import cats.effect.IO
+import cats.effect.concurrent.Ref
 import cats.kernel.Eq
 import cats.syntax.all._
 import io.circe._
@@ -18,26 +19,34 @@ final case class DecreaseStreamRetentionPeriodRequest(
     streamName: StreamName
 ) {
   def decreaseStreamRetention(
-      streams: Streams
-  ): ValidatedNel[KinesisMockException, Streams] =
+      streamsRef: Ref[IO, Streams]
+  ): IO[ValidatedResponse[Unit]] = streamsRef.get.flatMap { streams =>
     CommonValidations
-      .findStream(streamName, streams)
-      .andThen(stream =>
-        (
-          CommonValidations.validateStreamName(streamName),
-          CommonValidations.validateRetentionPeriodHours(retentionPeriodHours),
-          CommonValidations.isStreamActive(streamName, streams),
-          if (stream.retentionPeriod.toHours < retentionPeriodHours)
-            InvalidArgumentException(
-              s"Provided RetentionPeriodHours $retentionPeriodHours is greater than the currently defined retention period ${stream.retentionPeriod.toHours}"
-            ).invalidNel
-          else Valid(())
-        ).mapN((_, _, _, _) =>
-          streams.updateStream(
+      .validateStreamName(streamName)
+      .andThen(_ =>
+        CommonValidations
+          .findStream(streamName, streams)
+          .andThen(stream =>
+            (
+              CommonValidations
+                .validateRetentionPeriodHours(retentionPeriodHours),
+              CommonValidations.isStreamActive(streamName, streams),
+              if (stream.retentionPeriod.toHours < retentionPeriodHours)
+                InvalidArgumentException(
+                  s"Provided RetentionPeriodHours $retentionPeriodHours is greater than the currently defined retention period ${stream.retentionPeriod.toHours}"
+                ).invalidNel
+              else Valid(())
+            ).mapN((_, _, _) => stream)
+          )
+      )
+      .traverse(stream =>
+        streamsRef.update(x =>
+          x.updateStream(
             stream.copy(retentionPeriod = retentionPeriodHours.hours)
           )
         )
       )
+  }
 }
 
 object DecreaseStreamRetentionPeriodRequest {

--- a/src/main/scala/kinesis/mock/api/DescribeLimitsResponse.scala
+++ b/src/main/scala/kinesis/mock/api/DescribeLimitsResponse.scala
@@ -1,5 +1,7 @@
 package kinesis.mock.api
 
+import cats.effect.IO
+import cats.effect.concurrent.Ref
 import cats.kernel.Eq
 import io.circe._
 
@@ -8,11 +10,16 @@ import kinesis.mock.models.Streams
 final case class DescribeLimitsResponse(openShardCount: Int, shardLimit: Int)
 
 object DescribeLimitsResponse {
-  def get(shardLimit: Int, streams: Streams): DescribeLimitsResponse =
-    DescribeLimitsResponse(
-      streams.streams.values.map(_.shards.keys.count(_.isOpen)).sum,
-      shardLimit
-    )
+  def get(
+      shardLimit: Int,
+      streamsRef: Ref[IO, Streams]
+  ): IO[DescribeLimitsResponse] =
+    streamsRef.get.map { streams =>
+      DescribeLimitsResponse(
+        streams.streams.values.map(_.shards.keys.count(_.isOpen)).sum,
+        shardLimit
+      )
+    }
 
   implicit val describeLimitsResponseCirceEncoder
       : Encoder[DescribeLimitsResponse] =

--- a/src/main/scala/kinesis/mock/api/GetRecordsRequest.scala
+++ b/src/main/scala/kinesis/mock/api/GetRecordsRequest.scala
@@ -4,7 +4,8 @@ package api
 import scala.annotation.tailrec
 
 import cats.data.Validated._
-import cats.data._
+import cats.effect.IO
+import cats.effect.concurrent.Ref
 import cats.kernel.Eq
 import cats.syntax.all._
 import io.circe._
@@ -17,8 +18,8 @@ final case class GetRecordsRequest(
     shardIterator: ShardIterator
 ) {
   def getRecords(
-      streams: Streams
-  ): ValidatedNel[KinesisMockException, GetRecordsResponse] =
+      streamsRef: Ref[IO, Streams]
+  ): IO[ValidatedResponse[GetRecordsResponse]] = streamsRef.get.map { streams =>
     shardIterator.parse.andThen { parts =>
       CommonValidations
         .isStreamActiveOrUpdating(parts.streamName, streams)
@@ -155,6 +156,7 @@ final case class GetRecordsRequest(
             )
         )
     }
+  }
 }
 
 object GetRecordsRequest {

--- a/src/main/scala/kinesis/mock/api/GetShardIteratorRequest.scala
+++ b/src/main/scala/kinesis/mock/api/GetShardIteratorRequest.scala
@@ -4,7 +4,8 @@ package api
 import java.time.Instant
 
 import cats.data.Validated._
-import cats.data._
+import cats.effect.IO
+import cats.effect.concurrent.Ref
 import cats.kernel.Eq
 import cats.syntax.all._
 import io.circe._
@@ -21,91 +22,54 @@ final case class GetShardIteratorRequest(
     timestamp: Option[Instant]
 ) {
   def getShardIterator(
-      streams: Streams
-  ): ValidatedNel[KinesisMockException, GetShardIteratorResponse] =
-    CommonValidations
-      .findStream(streamName, streams)
-      .andThen(stream =>
-        (
-          CommonValidations.validateStreamName(streamName),
-          CommonValidations.isStreamActiveOrUpdating(streamName, streams),
-          startingSequenceNumber match {
-            case Some(sequenceNumber) =>
-              CommonValidations.validateSequenceNumber(sequenceNumber)
-            case None => Valid(())
-          },
-          (shardIteratorType, startingSequenceNumber, timestamp) match {
-            case (ShardIteratorType.AT_SEQUENCE_NUMBER, None, _) |
-                (ShardIteratorType.AFTER_SEQUENCE_NUMBER, None, _) =>
-              InvalidArgumentException(
-                s"StartingSequenceNumber must be provided for ShardIteratorType $shardIteratorType"
-              ).invalidNel
-            case (ShardIteratorType.AT_TIMESTAMP, _, None) =>
-              InvalidArgumentException(
-                s"Timestamp must be provided for ShardIteratorType $shardIteratorType"
-              ).invalidNel
-            case _ => Valid(())
-          },
-          CommonValidations.validateShardId(shardId),
-          CommonValidations.findShard(shardId, stream).andThen {
-            case (shard, data) =>
-              if (data.isEmpty)
-                Valid(
-                  GetShardIteratorResponse(
-                    ShardIterator.create(
-                      streamName,
-                      shardId,
-                      shard.sequenceNumberRange.startingSequenceNumber
-                    )
-                  )
-                )
-              else
+      streamsRef: Ref[IO, Streams]
+  ): IO[ValidatedResponse[GetShardIteratorResponse]] = streamsRef.get.map {
+    streams =>
+      CommonValidations
+        .validateStreamName(streamName)
+        .andThen(_ =>
+          CommonValidations
+            .findStream(streamName, streams)
+            .andThen(stream =>
+              (
+                CommonValidations.isStreamActiveOrUpdating(streamName, streams),
+                startingSequenceNumber match {
+                  case Some(sequenceNumber) =>
+                    CommonValidations.validateSequenceNumber(sequenceNumber)
+                  case None => Valid(())
+                },
                 (shardIteratorType, startingSequenceNumber, timestamp) match {
-                  case (ShardIteratorType.TRIM_HORIZON, _, _) =>
-                    Valid(
-                      GetShardIteratorResponse(
-                        ShardIterator.create(
-                          streamName,
-                          shardId,
-                          shard.sequenceNumberRange.startingSequenceNumber
-                        )
-                      )
-                    )
-                  case (ShardIteratorType.LATEST, _, _) =>
-                    Valid(
-                      GetShardIteratorResponse(
-                        ShardIterator.create(
-                          streamName,
-                          shardId,
-                          data.last.sequenceNumber
-                        )
-                      )
-                    )
-                  case (ShardIteratorType.AT_TIMESTAMP, _, Some(ts)) =>
-                    val now = Instant.now()
-                    if (ts.toEpochMilli > now.toEpochMilli)
-                      InvalidArgumentException(
-                        s"Timestamp cannot be in the future"
-                      ).invalidNel
-                    else
+                  case (ShardIteratorType.AT_SEQUENCE_NUMBER, None, _) |
+                      (ShardIteratorType.AFTER_SEQUENCE_NUMBER, None, _) =>
+                    InvalidArgumentException(
+                      s"StartingSequenceNumber must be provided for ShardIteratorType $shardIteratorType"
+                    ).invalidNel
+                  case (ShardIteratorType.AT_TIMESTAMP, _, None) =>
+                    InvalidArgumentException(
+                      s"Timestamp must be provided for ShardIteratorType $shardIteratorType"
+                    ).invalidNel
+                  case _ => Valid(())
+                },
+                CommonValidations.validateShardId(shardId),
+                CommonValidations.findShard(shardId, stream).andThen {
+                  case (shard, data) =>
+                    if (data.isEmpty)
                       Valid(
                         GetShardIteratorResponse(
                           ShardIterator.create(
                             streamName,
                             shardId,
-                            data
-                              .findLast(
-                                _.approximateArrivalTimestamp.toEpochMilli < ts.toEpochMilli
-                              )
-                              .map(_.sequenceNumber)
-                              .getOrElse(data.last.sequenceNumber)
+                            shard.sequenceNumberRange.startingSequenceNumber
                           )
                         )
                       )
-                  case (ShardIteratorType.AT_SEQUENCE_NUMBER, Some(seqNo), _) =>
-                    data.find(_.sequenceNumber == seqNo) match {
-                      case Some(record) =>
-                        if (record == data.head)
+                    else
+                      (
+                        shardIteratorType,
+                        startingSequenceNumber,
+                        timestamp
+                      ) match {
+                        case (ShardIteratorType.TRIM_HORIZON, _, _) =>
                           Valid(
                             GetShardIteratorResponse(
                               ShardIterator.create(
@@ -115,52 +79,104 @@ final case class GetShardIteratorRequest(
                               )
                             )
                           )
-                        else
+                        case (ShardIteratorType.LATEST, _, _) =>
                           Valid(
                             GetShardIteratorResponse(
                               ShardIterator.create(
                                 streamName,
                                 shardId,
-                                data(data.indexOf(record) - 1).sequenceNumber
+                                data.last.sequenceNumber
                               )
                             )
                           )
-                      case None =>
-                        ResourceNotFoundException(
-                          s"Unable to find record with provided SequenceNumber $seqNo in stream $streamName"
-                        ).invalidNel
-                    }
-
-                  case (
-                        ShardIteratorType.AFTER_SEQUENCE_NUMBER,
-                        Some(seqNo),
-                        _
-                      ) =>
-                    data.find(_.sequenceNumber == seqNo) match {
-                      case Some(record) =>
-                        Valid(
-                          GetShardIteratorResponse(
-                            ShardIterator.create(
-                              streamName,
-                              shardId,
-                              data(data.indexOf(record)).sequenceNumber
+                        case (ShardIteratorType.AT_TIMESTAMP, _, Some(ts)) =>
+                          val now = Instant.now()
+                          if (ts.toEpochMilli > now.toEpochMilli)
+                            InvalidArgumentException(
+                              s"Timestamp cannot be in the future"
+                            ).invalidNel
+                          else
+                            Valid(
+                              GetShardIteratorResponse(
+                                ShardIterator.create(
+                                  streamName,
+                                  shardId,
+                                  data
+                                    .findLast(
+                                      _.approximateArrivalTimestamp.toEpochMilli < ts.toEpochMilli
+                                    )
+                                    .map(_.sequenceNumber)
+                                    .getOrElse(data.last.sequenceNumber)
+                                )
+                              )
                             )
-                          )
-                        )
-                      case None =>
-                        ResourceNotFoundException(
-                          s"Unable to find record with provided SequenceNumber $seqNo in stream $streamName"
-                        ).invalidNel
-                    }
+                        case (
+                              ShardIteratorType.AT_SEQUENCE_NUMBER,
+                              Some(seqNo),
+                              _
+                            ) =>
+                          data.find(_.sequenceNumber == seqNo) match {
+                            case Some(record) =>
+                              if (record == data.head)
+                                Valid(
+                                  GetShardIteratorResponse(
+                                    ShardIterator.create(
+                                      streamName,
+                                      shardId,
+                                      shard.sequenceNumberRange.startingSequenceNumber
+                                    )
+                                  )
+                                )
+                              else
+                                Valid(
+                                  GetShardIteratorResponse(
+                                    ShardIterator.create(
+                                      streamName,
+                                      shardId,
+                                      data(
+                                        data.indexOf(record) - 1
+                                      ).sequenceNumber
+                                    )
+                                  )
+                                )
+                            case None =>
+                              ResourceNotFoundException(
+                                s"Unable to find record with provided SequenceNumber $seqNo in stream $streamName"
+                              ).invalidNel
+                          }
 
-                  case _ =>
-                    InvalidArgumentException(
-                      s"Request for GetShardIterator invalid. ShardIteratorType: $shardIteratorType, StartingSequenceNumber: $startingSequenceNumber, Timestamp: $timestamp"
-                    ).invalidNel
+                        case (
+                              ShardIteratorType.AFTER_SEQUENCE_NUMBER,
+                              Some(seqNo),
+                              _
+                            ) =>
+                          data.find(_.sequenceNumber == seqNo) match {
+                            case Some(record) =>
+                              Valid(
+                                GetShardIteratorResponse(
+                                  ShardIterator.create(
+                                    streamName,
+                                    shardId,
+                                    data(data.indexOf(record)).sequenceNumber
+                                  )
+                                )
+                              )
+                            case None =>
+                              ResourceNotFoundException(
+                                s"Unable to find record with provided SequenceNumber $seqNo in stream $streamName"
+                              ).invalidNel
+                          }
+
+                        case _ =>
+                          InvalidArgumentException(
+                            s"Request for GetShardIterator invalid. ShardIteratorType: $shardIteratorType, StartingSequenceNumber: $startingSequenceNumber, Timestamp: $timestamp"
+                          ).invalidNel
+                      }
                 }
-          }
-        ).mapN((_, _, _, _, _, res) => res)
-      )
+              ).mapN((_, _, _, _, res) => res)
+            )
+        )
+  }
 }
 
 object GetShardIteratorRequest {

--- a/src/main/scala/kinesis/mock/api/IncreaseStreamRetentionPeriodRequest.scala
+++ b/src/main/scala/kinesis/mock/api/IncreaseStreamRetentionPeriodRequest.scala
@@ -4,7 +4,8 @@ package api
 import scala.concurrent.duration._
 
 import cats.data.Validated._
-import cats.data._
+import cats.effect.IO
+import cats.effect.concurrent.Ref
 import cats.kernel.Eq
 import cats.syntax.all._
 import io.circe._
@@ -18,26 +19,34 @@ final case class IncreaseStreamRetentionPeriodRequest(
     streamName: StreamName
 ) {
   def increaseStreamRetention(
-      streams: Streams
-  ): ValidatedNel[KinesisMockException, Streams] =
+      streamsRef: Ref[IO, Streams]
+  ): IO[ValidatedResponse[Unit]] = streamsRef.get.flatMap { streams =>
     CommonValidations
-      .findStream(streamName, streams)
-      .andThen(stream =>
-        (
-          CommonValidations.validateStreamName(streamName),
-          CommonValidations.validateRetentionPeriodHours(retentionPeriodHours),
-          CommonValidations.isStreamActive(streamName, streams),
-          if (stream.retentionPeriod.toHours > retentionPeriodHours)
-            InvalidArgumentException(
-              s"Provided RetentionPeriodHours $retentionPeriodHours is less than the currently defined retention period ${stream.retentionPeriod.toHours}"
-            ).invalidNel
-          else Valid(())
-        ).mapN((_, _, _, _) =>
+      .validateStreamName(streamName)
+      .andThen(_ =>
+        CommonValidations
+          .findStream(streamName, streams)
+          .andThen(stream =>
+            (
+              CommonValidations
+                .validateRetentionPeriodHours(retentionPeriodHours),
+              CommonValidations.isStreamActive(streamName, streams),
+              if (stream.retentionPeriod.toHours > retentionPeriodHours)
+                InvalidArgumentException(
+                  s"Provided RetentionPeriodHours $retentionPeriodHours is less than the currently defined retention period ${stream.retentionPeriod.toHours}"
+                ).invalidNel
+              else Valid(())
+            ).mapN((_, _, _) => stream)
+          )
+      )
+      .traverse(stream =>
+        streamsRef.update(streams =>
           streams.updateStream(
             stream.copy(retentionPeriod = retentionPeriodHours.hours)
           )
         )
       )
+  }
 }
 
 object IncreaseStreamRetentionPeriodRequest {

--- a/src/main/scala/kinesis/mock/api/ListShardsRequest.scala
+++ b/src/main/scala/kinesis/mock/api/ListShardsRequest.scala
@@ -4,7 +4,8 @@ package api
 import java.time.Instant
 
 import cats.data.Validated._
-import cats.data._
+import cats.effect.IO
+import cats.effect.concurrent.Ref
 import cats.kernel.Eq
 import cats.syntax.all._
 import io.circe._
@@ -23,8 +24,8 @@ final case class ListShardsRequest(
     streamName: Option[StreamName]
 ) {
   def listShards(
-      streams: Streams
-  ): ValidatedNel[KinesisMockException, ListShardsResponse] =
+      streamsRef: Ref[IO, Streams]
+  ): IO[ValidatedResponse[ListShardsResponse]] = streamsRef.get.map { streams =>
     (
       exclusiveStartShardId,
       nextToken,
@@ -162,6 +163,7 @@ final case class ListShardsRequest(
           "Cannot define ExclusiveStartShardId, StreamCreationTimestamp or StreamName if NextToken is defined"
         ).invalidNel
     }
+  }
 }
 
 object ListShardsRequest {
@@ -220,7 +222,7 @@ object ListShardsRequest {
     s"$streamName::$shardId"
   def parseNextToken(
       nextToken: String
-  ): ValidatedNel[KinesisMockException, (StreamName, String)] = {
+  ): ValidatedResponse[(StreamName, String)] = {
     val split = nextToken.split("::")
     if (split.length != 2)
       InvalidArgumentException(s"NextToken is improperly formatted").invalidNel
@@ -228,7 +230,7 @@ object ListShardsRequest {
   }
   def validateShardFilter(
       shardFilter: ShardFilter
-  ): ValidatedNel[KinesisMockException, ShardFilter] =
+  ): ValidatedResponse[ShardFilter] =
     shardFilter.`type` match {
       case ShardFilterType.AFTER_SHARD_ID if shardFilter.shardId.isEmpty =>
         InvalidArgumentException(

--- a/src/main/scala/kinesis/mock/api/ListStreamsRequest.scala
+++ b/src/main/scala/kinesis/mock/api/ListStreamsRequest.scala
@@ -2,7 +2,8 @@ package kinesis.mock
 package api
 
 import cats.data.Validated._
-import cats.data._
+import cats.effect.IO
+import cats.effect.concurrent.Ref
 import cats.kernel.Eq
 import cats.syntax.all._
 import io.circe._
@@ -15,8 +16,8 @@ final case class ListStreamsRequest(
     limit: Option[Int]
 ) {
   def listStreams(
-      streams: Streams
-  ): ValidatedNel[KinesisMockException, ListStreamsResponse] =
+      streamsRef: Ref[IO, Streams]
+  ): IO[ValidatedResponse[ListStreamsResponse]] = streamsRef.get.map(streams =>
     (
       exclusiveStartStreamName match {
         case Some(streamName) =>
@@ -41,6 +42,7 @@ final case class ListStreamsRequest(
         else true
       ListStreamsResponse(hasMoreStreams, streamNames)
     })
+  )
 }
 
 object ListStreamsRequest {

--- a/src/main/scala/kinesis/mock/api/ListTagsForStreamRequest.scala
+++ b/src/main/scala/kinesis/mock/api/ListTagsForStreamRequest.scala
@@ -4,7 +4,8 @@ package api
 import scala.collection.SortedMap
 
 import cats.data.Validated._
-import cats.data._
+import cats.effect.IO
+import cats.effect.concurrent.Ref
 import cats.kernel.Eq
 import cats.syntax.all._
 import io.circe._
@@ -18,37 +19,45 @@ final case class ListTagsForStreamRequest(
     streamName: StreamName
 ) {
   def listTagsForStream(
-      streams: Streams
-  ): ValidatedNel[KinesisMockException, ListTagsForStreamResponse] =
-    CommonValidations
-      .findStream(streamName, streams)
-      .andThen(stream =>
-        (
-          CommonValidations.validateStreamName(streamName),
-          exclusiveStartTagKey match {
-            case Some(tagKey) =>
-              CommonValidations.validateTagKeys(List(tagKey))
-            case None => Valid(())
-          },
-          limit match {
-            case Some(l) => CommonValidations.validateLimit(l)
-            case None    => Valid(())
-          }
-        ).mapN((_, _, _) => {
-          val allTags = stream.tags.toList
-          val lastTagIndex = allTags.length - 1
-          val lim = limit.map(l => Math.min(l, 100)).getOrElse(100)
-          val firstIndex = exclusiveStartTagKey
-            .map(x => allTags.indexWhere(_._1 == x) + 1)
-            .getOrElse(0)
-          val lastIndex = Math.min(firstIndex + lim, lastTagIndex + 1)
-          val tags = SortedMap.from(allTags.slice(firstIndex, lastIndex))
-          val hasMoreTags =
-            if (lastTagIndex + 1 == lastIndex) false
-            else true
-          ListTagsForStreamResponse(hasMoreTags, TagList.fromTags(Tags(tags)))
-        })
-      )
+      streamsRef: Ref[IO, Streams]
+  ): IO[ValidatedResponse[ListTagsForStreamResponse]] =
+    streamsRef.get.map(streams =>
+      CommonValidations
+        .validateStreamName(streamName)
+        .andThen(_ =>
+          CommonValidations
+            .findStream(streamName, streams)
+            .andThen(stream =>
+              (
+                exclusiveStartTagKey match {
+                  case Some(tagKey) =>
+                    CommonValidations.validateTagKeys(List(tagKey))
+                  case None => Valid(())
+                },
+                limit match {
+                  case Some(l) => CommonValidations.validateLimit(l)
+                  case None    => Valid(())
+                }
+              ).mapN((_, _) => {
+                val allTags = stream.tags.toList
+                val lastTagIndex = allTags.length - 1
+                val lim = limit.map(l => Math.min(l, 100)).getOrElse(100)
+                val firstIndex = exclusiveStartTagKey
+                  .map(x => allTags.indexWhere(_._1 == x) + 1)
+                  .getOrElse(0)
+                val lastIndex = Math.min(firstIndex + lim, lastTagIndex + 1)
+                val tags = SortedMap.from(allTags.slice(firstIndex, lastIndex))
+                val hasMoreTags =
+                  if (lastTagIndex + 1 == lastIndex) false
+                  else true
+                ListTagsForStreamResponse(
+                  hasMoreTags,
+                  TagList.fromTags(Tags(tags))
+                )
+              })
+            )
+        )
+    )
 }
 
 object ListTagsForStreamRequest {

--- a/src/main/scala/kinesis/mock/api/MergeShardsRequest.scala
+++ b/src/main/scala/kinesis/mock/api/MergeShardsRequest.scala
@@ -4,9 +4,8 @@ package api
 import java.time.Instant
 
 import cats.data.Validated._
-import cats.data._
-import cats.effect.IO
-import cats.effect.concurrent.Semaphore
+import cats.effect.concurrent.{Ref, Semaphore}
+import cats.effect.{Concurrent, IO}
 import cats.kernel.Eq
 import cats.syntax.all._
 import io.circe._
@@ -21,115 +20,138 @@ final case class MergeShardsRequest(
     streamName: StreamName
 ) {
   def mergeShards(
-      streams: Streams,
-      shardSemaphores: Map[ShardSemaphoresKey, Semaphore[IO]]
-  ): IO[ValidatedNel[KinesisMockException, (Streams, ShardSemaphoresKey)]] =
-    CommonValidations
-      .findStream(streamName, streams)
-      .andThen { stream =>
-        (
-          CommonValidations.validateStreamName(streamName),
-          CommonValidations.isStreamActive(streamName, streams),
-          CommonValidations.validateShardId(shardToMerge),
-          CommonValidations.validateShardId(adjacentShardToMerge),
-          CommonValidations.findShard(adjacentShardToMerge, stream).andThen {
-            case (adjacentShard, adjacentData) =>
-              CommonValidations.isShardOpen(adjacentShard).andThen { _ =>
-                CommonValidations.findShard(shardToMerge, stream).andThen {
-                  case (shard, shardData) =>
-                    CommonValidations.isShardOpen(shard).andThen { _ =>
-                      if (
-                        adjacentShard.hashKeyRange
-                          .isAdjacent(shard.hashKeyRange)
-                      )
-                        Valid(
-                          ((adjacentShard, adjacentData), (shard, shardData))
-                        )
-                      else
-                        InvalidArgumentException(
-                          "Provided shards are not adjacent"
-                        ).invalidNel
-                    }
-                }
-              }
-          }
-        ).mapN {
-          case (
-                _,
-                _,
-                _,
-                _,
-                ((adjacentShard, adjacentData), (shard, shardData))
-              ) =>
-            (stream, (adjacentShard, adjacentData), (shard, shardData))
-        }
-      }
-      .traverse {
-        case (stream, (adjacentShard, adjacentData), (shard, shardData)) =>
-          val now = Instant.now()
-          val newShardIndex = stream.shards.keys.map(_.shardId.index).max + 1
-          val newShard: (Shard, List[KinesisRecord]) = Shard(
-            Some(adjacentShard.shardId.shardId),
-            None,
-            now,
-            HashKeyRange(
-              Math.max(
-                adjacentShard.hashKeyRange.endingHashKey.toLong,
-                shard.hashKeyRange.endingHashKey.toLong
-              ),
-              Math.min(
-                adjacentShard.hashKeyRange.startingHashKey.toLong,
-                shard.hashKeyRange.startingHashKey.toLong
-              )
-            ),
-            Some(shard.shardId.shardId),
-            SequenceNumberRange(
-              None,
-              if (
-                adjacentShard.sequenceNumberRange.startingSequenceNumber.numericValue < shard.sequenceNumberRange.startingSequenceNumber.numericValue
-              )
-                adjacentShard.sequenceNumberRange.startingSequenceNumber
-              else shard.sequenceNumberRange.startingSequenceNumber
-            ),
-            ShardId.create(newShardIndex)
-          ) -> List.empty
-
-          val oldShards: List[(Shard, List[KinesisRecord])] = List(
-            adjacentShard.copy(
-              closedTimestamp = Some(now),
-              sequenceNumberRange = adjacentShard.sequenceNumberRange
-                .copy(endingSequenceNumber = Some(SequenceNumber.shardEnd))
-            ) -> adjacentData,
-            shard.copy(
-              closedTimestamp = Some(now),
-              sequenceNumberRange = shard.sequenceNumberRange
-                .copy(endingSequenceNumber = Some(SequenceNumber.shardEnd))
-            ) -> shardData
-          )
-
-          shardSemaphores(
-            ShardSemaphoresKey(streamName, adjacentShard)
-          ).withPermit(
-            shardSemaphores(ShardSemaphoresKey(streamName, shard))
-              .withPermit(
-                IO(
-                  (
-                    streams
-                      .updateStream(
-                        stream.copy(
-                          shards = stream.shards.filterNot { case (s, _) =>
-                            s.shardId == adjacentShard.shardId || s.shardId == shard.shardId
+      streamsRef: Ref[IO, Streams],
+      shardSemaphoresRef: Ref[IO, Map[ShardSemaphoresKey, Semaphore[IO]]]
+  )(implicit C: Concurrent[IO]): IO[ValidatedResponse[Unit]] =
+    streamsRef.get.flatMap(streams =>
+      CommonValidations
+        .validateStreamName(streamName)
+        .andThen(_ =>
+          CommonValidations
+            .findStream(streamName, streams)
+            .andThen { stream =>
+              (
+                CommonValidations.isStreamActive(streamName, streams),
+                CommonValidations.validateShardId(shardToMerge),
+                CommonValidations.validateShardId(adjacentShardToMerge),
+                CommonValidations
+                  .findShard(adjacentShardToMerge, stream)
+                  .andThen { case (adjacentShard, adjacentData) =>
+                    CommonValidations.isShardOpen(adjacentShard).andThen { _ =>
+                      CommonValidations
+                        .findShard(shardToMerge, stream)
+                        .andThen { case (shard, shardData) =>
+                          CommonValidations.isShardOpen(shard).andThen { _ =>
+                            if (
+                              adjacentShard.hashKeyRange
+                                .isAdjacent(shard.hashKeyRange)
+                            )
+                              Valid(
+                                (
+                                  (adjacentShard, adjacentData),
+                                  (shard, shardData)
+                                )
+                              )
+                            else
+                              InvalidArgumentException(
+                                "Provided shards are not adjacent"
+                              ).invalidNel
                           }
-                            ++ (oldShards :+ newShard),
-                          streamStatus = StreamStatus.UPDATING
-                        )
-                      ),
-                    ShardSemaphoresKey(streamName, newShard._1)
-                  )
+                        }
+                    }
+                  }
+              ).mapN {
+                case (
+                      _,
+                      _,
+                      _,
+                      ((adjacentShard, adjacentData), (shard, shardData))
+                    ) =>
+                  (stream, (adjacentShard, adjacentData), (shard, shardData))
+              }
+            }
+        )
+        .traverse {
+          case (
+                stream,
+                (adjacentShard, adjacentData),
+                (shard, shardData)
+              ) =>
+            val now = Instant.now()
+            val newShardIndex =
+              stream.shards.keys.map(_.shardId.index).max + 1
+            val newShard: (Shard, List[KinesisRecord]) = Shard(
+              Some(adjacentShard.shardId.shardId),
+              None,
+              now,
+              HashKeyRange(
+                Math.max(
+                  adjacentShard.hashKeyRange.endingHashKey.toLong,
+                  shard.hashKeyRange.endingHashKey.toLong
+                ),
+                Math.min(
+                  adjacentShard.hashKeyRange.startingHashKey.toLong,
+                  shard.hashKeyRange.startingHashKey.toLong
                 )
+              ),
+              Some(shard.shardId.shardId),
+              SequenceNumberRange(
+                None,
+                if (
+                  adjacentShard.sequenceNumberRange.startingSequenceNumber.numericValue < shard.sequenceNumberRange.startingSequenceNumber.numericValue
+                )
+                  adjacentShard.sequenceNumberRange.startingSequenceNumber
+                else shard.sequenceNumberRange.startingSequenceNumber
+              ),
+              ShardId.create(newShardIndex)
+            ) -> List.empty
+
+            val oldShards: List[(Shard, List[KinesisRecord])] = List(
+              adjacentShard.copy(
+                closedTimestamp = Some(now),
+                sequenceNumberRange = adjacentShard.sequenceNumberRange
+                  .copy(endingSequenceNumber = Some(SequenceNumber.shardEnd))
+              ) -> adjacentData,
+              shard.copy(
+                closedTimestamp = Some(now),
+                sequenceNumberRange = shard.sequenceNumberRange
+                  .copy(endingSequenceNumber = Some(SequenceNumber.shardEnd))
+              ) -> shardData
+            )
+            shardSemaphoresRef.get.flatMap(shardSemaphores =>
+              shardSemaphores(
+                ShardSemaphoresKey(streamName, adjacentShard)
+              ).withPermit(
+                shardSemaphores(ShardSemaphoresKey(streamName, shard))
+                  .withPermit(
+                    for {
+                      _ <- streamsRef.update(x =>
+                        x.updateStream(
+                          stream.copy(
+                            shards = stream.shards.filterNot { case (s, _) =>
+                              s.shardId == adjacentShard.shardId || s.shardId == shard.shardId
+                            }
+                              ++ (oldShards :+ newShard),
+                            streamStatus = StreamStatus.UPDATING
+                          )
+                        )
+                      )
+                      newSemaphore <- Semaphore[IO](1)
+                      newShardsSemaphoreKey = ShardSemaphoresKey(
+                        streamName,
+                        newShard._1
+                      )
+                      res <- shardSemaphoresRef.update(shardsSemaphore =>
+                        shardsSemaphore ++ List(
+                          newShardsSemaphoreKey -> newSemaphore
+                        )
+                      )
+                    } yield res
+                  )
               )
-          )
-      }
+            )
+        }
+    )
 }
 
 object MergeShardsRequest {

--- a/src/main/scala/kinesis/mock/api/PutRecordRequest.scala
+++ b/src/main/scala/kinesis/mock/api/PutRecordRequest.scala
@@ -6,9 +6,8 @@ import scala.collection.SortedMap
 import java.time.Instant
 
 import cats.data.Validated._
-import cats.data._
 import cats.effect.IO
-import cats.effect.concurrent.Semaphore
+import cats.effect.concurrent.{Ref, Semaphore}
 import cats.kernel.Eq
 import cats.syntax.all._
 import io.circe._
@@ -25,79 +24,88 @@ final case class PutRecordRequest(
     streamName: StreamName
 ) {
   def putRecord(
-      streams: Streams,
-      shardSemaphores: Map[ShardSemaphoresKey, Semaphore[IO]]
-  ): IO[ValidatedNel[KinesisMockException, (Streams, PutRecordResponse)]] = {
-    val now = Instant.now()
-    CommonValidations
-      .findStream(streamName, streams)
-      .andThen { stream =>
-        (
-          CommonValidations.validateStreamName(streamName),
-          CommonValidations.isStreamActiveOrUpdating(streamName, streams),
-          CommonValidations.validateData(data),
-          sequenceNumberForOrdering match {
-            case None => Valid(())
-            case Some(seqNo) =>
-              seqNo.parse.andThen {
-                case parts: SequenceNumberParts
-                    if parts.seqTime.toEpochMilli > now.toEpochMilli =>
-                  InvalidArgumentException(
-                    s"Sequence time in the future"
-                  ).invalidNel
-                case x => Valid(x)
-              }
-          },
-          CommonValidations.validatePartitionKey(partitionKey),
-          explicitHashKey match {
-            case Some(explHashKeh) =>
-              CommonValidations.validateExplicitHashKey(explHashKeh)
-            case None => Valid(())
-          },
+      streamsRef: Ref[IO, Streams],
+      shardSemaphoresRef: Ref[IO, Map[ShardSemaphoresKey, Semaphore[IO]]]
+  ): IO[ValidatedResponse[PutRecordResponse]] = streamsRef.get.flatMap {
+    streams =>
+      val now = Instant.now()
+      CommonValidations
+        .validateStreamName(streamName)
+        .andThen(_ =>
           CommonValidations
-            .computeShard(partitionKey, explicitHashKey, stream)
-            .andThen { case (shard, records) =>
-              CommonValidations.isShardOpen(shard).map(_ => (shard, records))
+            .findStream(streamName, streams)
+            .andThen { stream =>
+              (
+                CommonValidations.isStreamActiveOrUpdating(streamName, streams),
+                CommonValidations.validateData(data),
+                sequenceNumberForOrdering match {
+                  case None => Valid(())
+                  case Some(seqNo) =>
+                    seqNo.parse.andThen {
+                      case parts: SequenceNumberParts
+                          if parts.seqTime.toEpochMilli > now.toEpochMilli =>
+                        InvalidArgumentException(
+                          s"Sequence time in the future"
+                        ).invalidNel
+                      case x => Valid(x)
+                    }
+                },
+                CommonValidations.validatePartitionKey(partitionKey),
+                explicitHashKey match {
+                  case Some(explHashKeh) =>
+                    CommonValidations.validateExplicitHashKey(explHashKeh)
+                  case None => Valid(())
+                },
+                CommonValidations
+                  .computeShard(partitionKey, explicitHashKey, stream)
+                  .andThen { case (shard, records) =>
+                    CommonValidations
+                      .isShardOpen(shard)
+                      .map(_ => (shard, records))
 
+                  }
+              ).mapN { case (_, _, _, _, _, (shard, records)) =>
+                (stream, shard, records)
+              }
             }
-        ).mapN { case (_, _, _, _, _, _, (shard, records)) =>
-          (stream, shard, records)
-        }
-      }
-      .traverse { case (stream, shard, records) =>
-        val seqNo = SequenceNumber.create(
-          shard.createdAtTimestamp,
-          shard.shardId.index,
-          None,
-          Some(records.length),
-          Some(now)
         )
-        // Use a semaphore to ensure synchronous operations on the shard
-        shardSemaphores(ShardSemaphoresKey(streamName, shard)).withPermit(
-          IO(
-            (
-              streams.updateStream {
-                stream.copy(
-                  shards = stream.shards ++ SortedMap(
-                    shard -> (records :+ KinesisRecord(
-                      now,
-                      data,
-                      stream.encryptionType,
-                      partitionKey,
-                      seqNo
-                    ))
+        .traverse { case (stream, shard, records) =>
+          val seqNo = SequenceNumber.create(
+            shard.createdAtTimestamp,
+            shard.shardId.index,
+            None,
+            Some(records.length),
+            Some(now)
+          )
+          // Use a semaphore to ensure synchronous operations on the shard
+          shardSemaphoresRef.get.flatMap(shardSemaphores =>
+            shardSemaphores(ShardSemaphoresKey(streamName, shard)).withPermit(
+              streamsRef
+                .update(x =>
+                  x.updateStream {
+                    stream.copy(
+                      shards = stream.shards ++ SortedMap(
+                        shard -> (records :+ KinesisRecord(
+                          now,
+                          data,
+                          stream.encryptionType,
+                          partitionKey,
+                          seqNo
+                        ))
+                      )
+                    )
+                  }
+                )
+                .as(
+                  PutRecordResponse(
+                    stream.encryptionType,
+                    seqNo,
+                    shard.shardId.shardId
                   )
                 )
-              },
-              PutRecordResponse(
-                stream.encryptionType,
-                seqNo,
-                shard.shardId.shardId
-              )
             )
           )
-        )
-      }
+        }
   }
 }
 

--- a/src/main/scala/kinesis/mock/api/PutRecordsRequest.scala
+++ b/src/main/scala/kinesis/mock/api/PutRecordsRequest.scala
@@ -5,9 +5,8 @@ import java.time.Instant
 
 import cats.Parallel
 import cats.data.Validated._
-import cats.data._
 import cats.effect.IO
-import cats.effect.concurrent.Semaphore
+import cats.effect.concurrent.{Ref, Semaphore}
 import cats.kernel.Eq
 import cats.syntax.all._
 import io.circe._
@@ -20,107 +19,123 @@ final case class PutRecordsRequest(
     streamName: StreamName
 ) {
   def putRecords(
-      streams: Streams,
-      shardSemaphores: Map[ShardSemaphoresKey, Semaphore[IO]]
+      streamsRef: Ref[IO, Streams],
+      shardSemaphoresRef: Ref[IO, Map[ShardSemaphoresKey, Semaphore[IO]]]
   )(implicit
       P: Parallel[IO]
-  ): IO[ValidatedNel[KinesisMockException, (Streams, PutRecordsResponse)]] = {
-    val now = Instant.now()
-
-    CommonValidations
-      .findStream(streamName, streams)
-      .andThen { stream =>
-        (
-          CommonValidations.validateStreamName(streamName),
-          CommonValidations.isStreamActiveOrUpdating(streamName, streams),
-          records.traverse(x =>
-            (
-              CommonValidations.validatePartitionKey(x.partitionKey),
-              x.explicitHashKey match {
-                case Some(explHashKey) =>
-                  CommonValidations.validateExplicitHashKey(explHashKey)
-                case None => Valid(())
-              },
-              CommonValidations.validateData(x.data),
-              CommonValidations
-                .computeShard(x.partitionKey, x.explicitHashKey, stream)
-                .andThen { case (shard, records) =>
-                  CommonValidations
-                    .isShardOpen(shard)
-                    .map(_ => (shard, records))
-                }
-            ).mapN { case (_, _, _, (shard, records)) => (shard, records, x) }
-          )
-        ).mapN((_, _, recs) => (stream, recs))
-      }
-      .traverse { case (stream, recs) =>
-        val grouped = recs
-          .groupBy { case (shard, records, _) =>
-            (shard, records)
-          }
-          .map { case ((shard, records), list) =>
-            (shard, records) ->
-              list.map(_._3).zipWithIndex.map { case (entry, index) =>
-                val seqNo = SequenceNumber.create(
-                  shard.createdAtTimestamp,
-                  shard.shardId.index,
-                  None,
-                  Some(records.length + index),
-                  Some(now)
-                )
-                (
-                  KinesisRecord(
-                    now,
-                    entry.data,
-                    stream.encryptionType,
-                    entry.partitionKey,
-                    seqNo
-                  ),
-                  PutRecordsResultEntry(
-                    None,
-                    None,
-                    Some(seqNo),
-                    Some(shard.shardId.shardId)
-                  )
-                )
-              }
-          }
-          .toList
-
-        grouped
-          .parTraverse { case ((shard, currentRecords), recordsToAdd) =>
-            shardSemaphores(ShardSemaphoresKey(streamName, shard)).withPermit(
-              IO(
-                (
-                  shard,
+  ): IO[ValidatedResponse[PutRecordsResponse]] =
+    streamsRef.get.flatMap { streams =>
+      val now = Instant.now()
+      CommonValidations
+        .validateStreamName(streamName)
+        .andThen(_ =>
+          CommonValidations
+            .findStream(streamName, streams)
+            .andThen { stream =>
+              (
+                CommonValidations.isStreamActiveOrUpdating(streamName, streams),
+                records.traverse(x =>
                   (
-                    currentRecords ++ recordsToAdd.map(_._1),
-                    recordsToAdd.map(_._2)
-                  )
-                )
-              )
-            )
-          }
-          .map { newShards =>
-            (
-              streams.updateStream(
-                stream.copy(
-                  shards = stream.shards ++ newShards.map {
-                    case (shard, (records, _)) => shard -> records
+                    CommonValidations.validatePartitionKey(x.partitionKey),
+                    x.explicitHashKey match {
+                      case Some(explHashKey) =>
+                        CommonValidations.validateExplicitHashKey(explHashKey)
+                      case None => Valid(())
+                    },
+                    CommonValidations.validateData(x.data),
+                    CommonValidations
+                      .computeShard(x.partitionKey, x.explicitHashKey, stream)
+                      .andThen { case (shard, records) =>
+                        CommonValidations
+                          .isShardOpen(shard)
+                          .map(_ => (shard, records))
+                      }
+                  ).mapN { case (_, _, _, (shard, records)) =>
+                    (shard, records, x)
                   }
                 )
-              ),
-              PutRecordsResponse(
-                stream.encryptionType,
-                0,
-                newShards.flatMap { case (_, (_, resultEntries)) =>
-                  resultEntries
+              ).mapN((_, recs) => (stream, recs))
+            }
+        )
+        .traverse { case (stream, recs) =>
+          val grouped = recs
+            .groupBy { case (shard, records, _) =>
+              (shard, records)
+            }
+            .map { case ((shard, records), list) =>
+              (shard, records) ->
+                list.map(_._3).zipWithIndex.map { case (entry, index) =>
+                  val seqNo = SequenceNumber.create(
+                    shard.createdAtTimestamp,
+                    shard.shardId.index,
+                    None,
+                    Some(records.length + index),
+                    Some(now)
+                  )
+                  (
+                    KinesisRecord(
+                      now,
+                      entry.data,
+                      stream.encryptionType,
+                      entry.partitionKey,
+                      seqNo
+                    ),
+                    PutRecordsResultEntry(
+                      None,
+                      None,
+                      Some(seqNo),
+                      Some(shard.shardId.shardId)
+                    )
+                  )
                 }
+            }
+            .toList
+
+          shardSemaphoresRef.get.flatMap { shardSemaphores =>
+            val keys = grouped.map { case ((shard, _), _) =>
+              ShardSemaphoresKey(streamName, shard)
+            }
+
+            val semaphores = shardSemaphores.toList.filter { case (key, _) =>
+              keys.contains(key)
+            }
+
+            for {
+              _ <- semaphores.parTraverse { case (_, semaphore) =>
+                semaphore.acquire
+              }
+              newShards = grouped.map {
+                case ((shard, currentRecords), recordsToAdd) =>
+                  (
+                    shard,
+                    (
+                      currentRecords ++ recordsToAdd.map(_._1),
+                      recordsToAdd.map(_._2)
+                    )
+                  )
+              }
+              _ <- streamsRef.update(x =>
+                x.updateStream(
+                  stream.copy(
+                    shards = stream.shards ++ newShards.map {
+                      case (shard, (records, _)) => shard -> records
+                    }
+                  )
+                )
               )
+              _ <- semaphores.parTraverse { case (_, semaphore) =>
+                semaphore.release
+              }
+            } yield PutRecordsResponse(
+              stream.encryptionType,
+              0,
+              newShards.flatMap { case (_, (_, resultEntries)) =>
+                resultEntries
+              }
             )
           }
-      }
-  }
+        }
+    }
 }
 
 object PutRecordsRequest {

--- a/src/main/scala/kinesis/mock/api/SplitShardRequest.scala
+++ b/src/main/scala/kinesis/mock/api/SplitShardRequest.scala
@@ -4,9 +4,8 @@ package api
 import java.time.Instant
 
 import cats.data.Validated._
-import cats.data._
-import cats.effect.IO
-import cats.effect.concurrent.Semaphore
+import cats.effect.concurrent.{Ref, Semaphore}
+import cats.effect.{Concurrent, IO}
 import cats.kernel.Eq
 import cats.syntax.all._
 import io.circe._
@@ -21,110 +20,121 @@ final case class SplitShardRequest(
     streamName: StreamName
 ) {
   def splitShard(
-      streams: Streams,
-      shardSemaphores: Map[ShardSemaphoresKey, Semaphore[IO]],
+      streamsRef: Ref[IO, Streams],
+      shardSemaphoresRef: Ref[IO, Map[ShardSemaphoresKey, Semaphore[IO]]],
       shardLimit: Int
-  ): IO[
-    ValidatedNel[KinesisMockException, (Streams, List[ShardSemaphoresKey])]
-  ] = CommonValidations
-    .findStream(streamName, streams)
-    .andThen { stream =>
-      (
-        CommonValidations.validateStreamName(streamName),
-        CommonValidations.isStreamActive(streamName, streams),
-        CommonValidations.validateShardId(shardToSplit),
-        if (!newStartingHashKey.matches("0|([1-9]\\d{0,38})")) {
-          InvalidArgumentException(
-            "NewStartingHashKey contains invalid characters"
-          ).invalidNel
-        } else Valid(newStartingHashKey),
-        if (streams.streams.values.map(_.shards.size).sum + 1 > shardLimit)
-          LimitExceededException(
-            "Operation would exceed the configured shard limit for the account"
-          ).invalidNel
-        else Valid(()),
-        CommonValidations.findShard(shardToSplit, stream).andThen {
-          case (shard, shardData) =>
-            CommonValidations.isShardOpen(shard).andThen { _ =>
-              val newStartingHashKeyNumber = BigInt(newStartingHashKey)
-              if (
-                newStartingHashKeyNumber >= shard.hashKeyRange.startingHashKey && newStartingHashKeyNumber <= shard.hashKeyRange.endingHashKey
-              )
-                Valid((shard, shardData))
-              else
-                InvalidArgumentException(
-                  s"NewStartingHashKey is not within the hash range shard ${shard.shardId}"
-                ).invalidNel
+  )(implicit C: Concurrent[IO]): IO[ValidatedResponse[Unit]] =
+    streamsRef.get.flatMap { streams =>
+      CommonValidations
+        .validateStreamName(streamName)
+        .andThen(_ =>
+          CommonValidations
+            .findStream(streamName, streams)
+            .andThen { stream =>
+              (
+                CommonValidations.isStreamActive(streamName, streams),
+                CommonValidations.validateShardId(shardToSplit),
+                if (!newStartingHashKey.matches("0|([1-9]\\d{0,38})")) {
+                  InvalidArgumentException(
+                    "NewStartingHashKey contains invalid characters"
+                  ).invalidNel
+                } else Valid(newStartingHashKey),
+                if (
+                  streams.streams.values.map(_.shards.size).sum + 1 > shardLimit
+                )
+                  LimitExceededException(
+                    "Operation would exceed the configured shard limit for the account"
+                  ).invalidNel
+                else Valid(()),
+                CommonValidations.findShard(shardToSplit, stream).andThen {
+                  case (shard, shardData) =>
+                    CommonValidations.isShardOpen(shard).andThen { _ =>
+                      val newStartingHashKeyNumber = BigInt(newStartingHashKey)
+                      if (
+                        newStartingHashKeyNumber >= shard.hashKeyRange.startingHashKey && newStartingHashKeyNumber <= shard.hashKeyRange.endingHashKey
+                      )
+                        Valid((shard, shardData))
+                      else
+                        InvalidArgumentException(
+                          s"NewStartingHashKey is not within the hash range shard ${shard.shardId}"
+                        ).invalidNel
+                    }
+                }
+              ).mapN { case (_, _, _, _, (shard, shardData)) =>
+                (shard, shardData, stream)
+              }
             }
-        }
-      ).mapN { case (_, _, _, _, _, (shard, shardData)) =>
-        (shard, shardData, stream)
-      }
-    }
-    .traverse { case (shard, shardData, stream) =>
-      val now = Instant.now()
-      val newStartingHashKeyNumber = BigInt(newStartingHashKey)
-      val newShardIndex1 = stream.shards.keys.map(_.shardId.index).max + 1
-      val newShardIndex2 = newShardIndex1 + 1
-      val newShard1: (Shard, List[KinesisRecord]) = Shard(
-        None,
-        None,
-        now,
-        HashKeyRange(
-          shard.hashKeyRange.startingHashKey,
-          newStartingHashKeyNumber - BigInt(1)
-        ),
-        Some(shard.shardId.shardId),
-        SequenceNumberRange(
-          None,
-          SequenceNumber.create(now, newShardIndex1, None, None, None)
-        ),
-        ShardId.create(newShardIndex1)
-      ) -> List.empty
-
-      val newShard2: (Shard, List[KinesisRecord]) = Shard(
-        None,
-        None,
-        now,
-        HashKeyRange(
-          newStartingHashKeyNumber,
-          shard.hashKeyRange.endingHashKey
-        ),
-        Some(shard.shardId.shardId),
-        SequenceNumberRange(
-          None,
-          SequenceNumber.create(now, newShardIndex2, None, None, None)
-        ),
-        ShardId.create(newShardIndex2)
-      ) -> List.empty
-
-      val newShards = List(newShard1, newShard2)
-
-      val oldShard: (Shard, List[KinesisRecord]) = shard.copy(
-        closedTimestamp = Some(now),
-        sequenceNumberRange = shard.sequenceNumberRange.copy(
-          endingSequenceNumber = Some(SequenceNumber.shardEnd)
         )
-      ) -> shardData
-
-      shardSemaphores(ShardSemaphoresKey(streamName, shard)).withPermit(
-        IO(
-          (
-            streams.updateStream(
-              stream.copy(
-                shards = stream.shards.filterNot { case (shard, _) =>
-                  shard.shardId == oldShard._1.shardId
-                } ++ (newShards :+ oldShard),
-                streamStatus = StreamStatus.UPDATING
-              )
+        .traverse { case (shard, shardData, stream) =>
+          val now = Instant.now()
+          val newStartingHashKeyNumber = BigInt(newStartingHashKey)
+          val newShardIndex1 = stream.shards.keys.map(_.shardId.index).max + 1
+          val newShardIndex2 = newShardIndex1 + 1
+          val newShard1: (Shard, List[KinesisRecord]) = Shard(
+            None,
+            None,
+            now,
+            HashKeyRange(
+              shard.hashKeyRange.startingHashKey,
+              newStartingHashKeyNumber - BigInt(1)
             ),
-            List(
-              ShardSemaphoresKey(streamName, newShard1._1),
-              ShardSemaphoresKey(streamName, newShard2._1)
+            Some(shard.shardId.shardId),
+            SequenceNumberRange(
+              None,
+              SequenceNumber.create(now, newShardIndex1, None, None, None)
+            ),
+            ShardId.create(newShardIndex1)
+          ) -> List.empty
+
+          val newShard2: (Shard, List[KinesisRecord]) = Shard(
+            None,
+            None,
+            now,
+            HashKeyRange(
+              newStartingHashKeyNumber,
+              shard.hashKeyRange.endingHashKey
+            ),
+            Some(shard.shardId.shardId),
+            SequenceNumberRange(
+              None,
+              SequenceNumber.create(now, newShardIndex2, None, None, None)
+            ),
+            ShardId.create(newShardIndex2)
+          ) -> List.empty
+
+          val newShards = List(newShard1, newShard2)
+
+          val oldShard: (Shard, List[KinesisRecord]) = shard.copy(
+            closedTimestamp = Some(now),
+            sequenceNumberRange = shard.sequenceNumberRange.copy(
+              endingSequenceNumber = Some(SequenceNumber.shardEnd)
             )
-          )
-        )
-      )
+          ) -> shardData
+
+          shardSemaphoresRef.get.flatMap { shardSemaphores =>
+            shardSemaphores(ShardSemaphoresKey(streamName, shard)).withPermit(
+              streamsRef.update(x =>
+                x.updateStream(
+                  stream.copy(
+                    shards = stream.shards.filterNot { case (shard, _) =>
+                      shard.shardId == oldShard._1.shardId
+                    } ++ (newShards :+ oldShard),
+                    streamStatus = StreamStatus.UPDATING
+                  )
+                )
+              )
+            ) *> Semaphore[IO](1)
+              .flatMap(x => Semaphore[IO](1).map(y => List(x, y)))
+              .flatMap(semaphores =>
+                shardSemaphoresRef.update(shardsSemaphore =>
+                  shardsSemaphore ++ List(
+                    ShardSemaphoresKey(streamName, newShard1._1),
+                    ShardSemaphoresKey(streamName, newShard2._1)
+                  ).zip(semaphores)
+                )
+              )
+          }
+        }
     }
 }
 

--- a/src/main/scala/kinesis/mock/api/StartStreamEncryptionRequest.scala
+++ b/src/main/scala/kinesis/mock/api/StartStreamEncryptionRequest.scala
@@ -2,7 +2,8 @@ package kinesis.mock
 package api
 
 import cats.data.Validated._
-import cats.data._
+import cats.effect.IO
+import cats.effect.concurrent.Ref
 import cats.kernel.Eq
 import cats.syntax.all._
 import io.circe._
@@ -16,18 +17,24 @@ final case class StartStreamEncryptionRequest(
     streamName: StreamName
 ) {
   def startStreamEncryption(
-      streams: Streams
-  ): ValidatedNel[KinesisMockException, Streams] =
+      streamsRef: Ref[IO, Streams]
+  ): IO[ValidatedResponse[Unit]] = streamsRef.get.flatMap { streams =>
     CommonValidations
-      .findStream(streamName, streams)
-      .andThen(stream =>
-        (
-          CommonValidations.validateStreamName(streamName),
-          CommonValidations.validateKeyId(keyId),
-          CommonValidations.isKmsEncryptionType(encryptionType),
-          CommonValidations.isStreamActive(streamName, streams)
-        ).mapN((_, _, _, _) =>
-          streams.updateStream(
+      .validateStreamName(streamName)
+      .andThen(_ =>
+        CommonValidations
+          .findStream(streamName, streams)
+          .andThen(stream =>
+            (
+              CommonValidations.validateKeyId(keyId),
+              CommonValidations.isKmsEncryptionType(encryptionType),
+              CommonValidations.isStreamActive(streamName, streams)
+            ).mapN((_, _, _) => stream)
+          )
+      )
+      .traverse(stream =>
+        streamsRef.update(x =>
+          x.updateStream(
             stream.copy(
               encryptionType = encryptionType,
               streamStatus = StreamStatus.UPDATING,
@@ -36,6 +43,7 @@ final case class StartStreamEncryptionRequest(
           )
         )
       )
+  }
 }
 
 object StartStreamEncryptionRequest {

--- a/src/main/scala/kinesis/mock/cache/Cache.scala
+++ b/src/main/scala/kinesis/mock/cache/Cache.scala
@@ -11,11 +11,12 @@ import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 import kinesis.mock.api._
 import kinesis.mock.models._
+import kinesis.mock.syntax.io._
 import kinesis.mock.syntax.semaphore._
 
 class Cache private (
     streamsRef: Ref[IO, Streams],
-    shardsSemaphoresRef: Ref[IO, Map[ShardSemaphoresKey, Semaphore[IO]]],
+    shardSemaphoresRef: Ref[IO, Map[ShardSemaphoresKey, Semaphore[IO]]],
     semaphores: CacheSemaphores,
     config: CacheConfig,
     supervisor: Supervisor[IO]
@@ -26,31 +27,28 @@ class Cache private (
   def addTagsToStream(
       req: AddTagsToStreamRequest,
       context: LoggingContext
-  ): IO[Either[KinesisMockException, Unit]] = {
+  ): IO[EitherResponse[Unit]] = {
     val ctx = context + ("streamName" -> req.streamName.streamName)
     logger.debug(ctx.context)("Processing AddTagsToStream request") *>
       logger.trace(ctx.addJson("request", req.asJson).context)(
         "Logging request"
       ) *>
       semaphores.addTagsToStream.tryAcquireRelease(
-        streamsRef.get.flatMap(streams =>
-          req
-            .addTagsToStream(streams)
-            .traverse(streamsRef.set)
-            .map(_.toEither.leftMap(KinesisMockException.aggregate))
-            .flatTap(
-              _.fold(
-                e =>
-                  logger.warn(ctx.context, e)(
-                    "Adding tags to stream was unuccessful"
-                  ),
-                _ =>
-                  logger.debug(ctx.context)(
-                    "Successfully added tags to the stream"
-                  )
-              )
+        req
+          .addTagsToStream(streamsRef)
+          .aggregateErrors
+          .flatTap(
+            _.fold(
+              e =>
+                logger.warn(ctx.context, e)(
+                  "Adding tags to stream was unuccessful"
+                ),
+              _ =>
+                logger.debug(ctx.context)(
+                  "Successfully added tags to the stream"
+                )
             )
-        ),
+          ),
         logger
           .warn(ctx.context)("Rate limit exceeded for AddTagsToStream")
           .as(
@@ -65,32 +63,28 @@ class Cache private (
   def removeTagsFromStream(
       req: RemoveTagsFromStreamRequest,
       context: LoggingContext
-  ): IO[Either[KinesisMockException, Unit]] = {
+  ): IO[EitherResponse[Unit]] = {
     val ctx = context + ("streamName" -> req.streamName.streamName)
     logger.debug(ctx.context)("Processing RemoveTagsFromStream request") *>
       logger.trace(ctx.addJson("request", req.asJson).context)(
         "Logging request"
       ) *>
       semaphores.removeTagsFromStream.tryAcquireRelease(
-        streamsRef.get.flatMap(streams =>
-          req
-            .removeTagsFromStream(streams)
-            .toEither
-            .leftMap(KinesisMockException.aggregate)
-            .traverse(streamsRef.set)
-            .flatTap(
-              _.fold(
-                e =>
-                  logger.warn(ctx.context, e)(
-                    "Removing tags from stream was unuccessful"
-                  ),
-                _ =>
-                  logger.debug(ctx.context)(
-                    "Successfully removed tags from the stream"
-                  )
-              )
+        req
+          .removeTagsFromStream(streamsRef)
+          .aggregateErrors
+          .flatTap(
+            _.fold(
+              e =>
+                logger.warn(ctx.context, e)(
+                  "Removing tags from stream was unuccessful"
+                ),
+              _ =>
+                logger.debug(ctx.context)(
+                  "Successfully removed tags from the stream"
+                )
             )
-        ),
+          ),
         logger
           .warn(ctx.context)("Rate limit exceeded for RemoveTagsFromStream")
           .as(
@@ -109,7 +103,7 @@ class Cache private (
   )(implicit
       T: Timer[IO],
       CS: ContextShift[IO]
-  ): IO[Either[KinesisMockException, Unit]] = {
+  ): IO[EitherResponse[Unit]] = {
     val ctx = context + ("streamName" -> req.streamName.streamName)
     logger.debug(ctx.context)("Processing CreateStream request") *>
       logger.trace(ctx.addJson("request", req.asJson).context)(
@@ -117,16 +111,15 @@ class Cache private (
       ) *>
       semaphores.createStream.tryAcquireRelease(
         for {
-          streams <- streamsRef.get
-          createStreamsRes = req
+          createStreamsRes <- req
             .createStream(
-              streams,
+              streamsRef,
+              shardSemaphoresRef,
               config.shardLimit,
               config.awsRegion,
               config.awsAccountId
             )
-            .toEither
-            .leftMap(KinesisMockException.aggregate)
+            .aggregateErrors
           _ <- createStreamsRes.fold(
             e =>
               logger.warn(ctx.context, e)(
@@ -137,35 +130,24 @@ class Cache private (
                 "Successfully created stream"
               )
           )
-          res <- createStreamsRes
-            .traverse { case (updated, shardSemaphoreKeys) =>
-              for {
-                _ <- streamsRef.set(updated)
-                newShardSemaphores <- shardSemaphoreKeys
-                  .traverse(key => Semaphore[IO](1).map(s => key -> s))
-                _ <- shardsSemaphoresRef.update(shardSemaphores =>
-                  shardSemaphores ++ newShardSemaphores
-                )
-                r <- supervisor
-                  .supervise(
-                    logger.debug(ctx.context)(
-                      s"Delaying setting stream to active for ${config.createStreamDuration.toString}"
-                    ) *>
-                      IO.sleep(config.createStreamDuration) *>
-                      logger.debug(ctx.context)(
-                        s"Setting stream to active"
-                      ) *>
-                      streamsRef
-                        .set(
-                          updated.findAndUpdateStream(req.streamName)(x =>
-                            x.copy(streamStatus = StreamStatus.ACTIVE)
-                          )
-                        )
+          _ <- supervisor
+            .supervise(
+              logger.debug(ctx.context)(
+                s"Delaying setting stream to active for ${config.createStreamDuration.toString}"
+              ) *>
+                IO.sleep(config.createStreamDuration) *>
+                logger.debug(ctx.context)(
+                  s"Setting stream to active"
+                ) *>
+                streamsRef
+                  .update(streams =>
+                    streams.findAndUpdateStream(req.streamName)(x =>
+                      x.copy(streamStatus = StreamStatus.ACTIVE)
+                    )
                   )
-                  .void
-              } yield r
-            }
-        } yield res,
+            )
+            .void
+        } yield createStreamsRes,
         logger
           .warn(ctx.context)("Rate limit exceeded for CreateStream")
           .as(
@@ -181,10 +163,7 @@ class Cache private (
   def deleteStream(
       req: DeleteStreamRequest,
       context: LoggingContext
-  )(implicit
-      T: Timer[IO],
-      CS: ContextShift[IO]
-  ): IO[Either[KinesisMockException, Unit]] = {
+  )(implicit T: Timer[IO]): IO[EitherResponse[Unit]] = {
     val ctx = context + ("streamName" -> req.streamName.streamName)
     logger.debug(ctx.context)("Processing DeleteStream request") *>
       logger.trace(ctx.addJson("request", req.asJson).context)(
@@ -192,12 +171,10 @@ class Cache private (
       ) *>
       semaphores.deleteStream.tryAcquireRelease(
         for {
-          streams <- streamsRef.get
-          deleteStreamrRes = req
-            .deleteStream(streams)
-            .toEither
-            .leftMap(KinesisMockException.aggregate)
-          _ <- deleteStreamrRes.fold(
+          deleteStreamRes <- req
+            .deleteStream(streamsRef, shardSemaphoresRef)
+            .aggregateErrors
+          _ <- deleteStreamRes.fold(
             e =>
               logger.warn(ctx.context, e)(
                 "Deleting stream was unuccessful"
@@ -207,31 +184,19 @@ class Cache private (
                 "Successfully deleted stream"
               )
           )
-          res <-
-            deleteStreamrRes.traverse { case (updated, shardSemaphoreKeys) =>
-              for {
-                _ <- streamsRef.set(updated)
-                _ <- shardsSemaphoresRef.update(shardsSemaphores =>
-                  shardsSemaphores -- shardSemaphoreKeys
-                )
-                r <- supervisor
-                  .supervise(
-                    logger.debug(ctx.context)(
-                      s"Delaying removing the stream for ${config.deleteStreamDuration.toString}"
-                    ) *>
-                      IO.sleep(config.deleteStreamDuration) *>
-                      logger.debug(ctx.context)(
-                        s"Removing stream"
-                      ) *>
-                      streamsRef.set(
-                        updated.removeStream(req.streamName)
-                      )
-                  )
-                  .void
-              } yield r
-
-            }
-        } yield res,
+          _ <- supervisor
+            .supervise(
+              logger.debug(ctx.context)(
+                s"Delaying removing the stream for ${config.deleteStreamDuration.toString}"
+              ) *>
+                IO.sleep(config.deleteStreamDuration) *>
+                logger.debug(ctx.context)(
+                  s"Removing stream"
+                ) *>
+                streamsRef.update(x => x.removeStream(req.streamName))
+            )
+            .void
+        } yield deleteStreamRes,
         logger
           .warn(ctx.context)("Rate limit exceeded for DeleteStream")
           .as(
@@ -247,7 +212,7 @@ class Cache private (
   def decreaseStreamRetention(
       req: DecreaseStreamRetentionPeriodRequest,
       context: LoggingContext
-  ): IO[Either[KinesisMockException, Unit]] = {
+  ): IO[EitherResponse[Unit]] = {
     val ctx = context + ("streamName" -> req.streamName.streamName)
     logger.debug(ctx.context)(
       "Processing DecreaseStreamRetentionPeriod request"
@@ -255,31 +220,27 @@ class Cache private (
       logger.trace(ctx.addJson("request", req.asJson).context)(
         "Logging request"
       ) *>
-      streamsRef.get.flatMap(streams =>
-        req
-          .decreaseStreamRetention(streams)
-          .toEither
-          .leftMap(KinesisMockException.aggregate)
-          .traverse(streamsRef.set)
-          .flatTap(
-            _.fold(
-              e =>
-                logger.warn(ctx.context, e)(
-                  "Decreasing the stream retention period was unuccessful"
-                ),
-              _ =>
-                logger.debug(ctx.context)(
-                  "Successfully decreased the stream retention period "
-                )
-            )
+      req
+        .decreaseStreamRetention(streamsRef)
+        .aggregateErrors
+        .flatTap(
+          _.fold(
+            e =>
+              logger.warn(ctx.context, e)(
+                "Decreasing the stream retention period was unuccessful"
+              ),
+            _ =>
+              logger.debug(ctx.context)(
+                "Successfully decreased the stream retention period "
+              )
           )
-      )
+        )
   }
 
   def increaseStreamRetention(
       req: IncreaseStreamRetentionPeriodRequest,
       context: LoggingContext
-  ): IO[Either[KinesisMockException, Unit]] = {
+  ): IO[EitherResponse[Unit]] = {
     val ctx = context + ("streamName" -> req.streamName.streamName)
     logger.debug(ctx.context)(
       "Processing IncreaseStreamRetentionPeriod request"
@@ -287,40 +248,39 @@ class Cache private (
       logger.trace(ctx.addJson("request", req.asJson).context)(
         "Logging request"
       ) *>
-      streamsRef.get.flatMap(streams =>
-        req
-          .increaseStreamRetention(streams)
-          .toEither
-          .leftMap(KinesisMockException.aggregate)
-          .traverse(streamsRef.set)
-          .flatTap(
-            _.fold(
-              e =>
-                logger.warn(ctx.context, e)(
-                  "Increasing the stream retention period was unuccessful"
-                ),
-              _ =>
-                logger.debug(ctx.context)(
-                  "Successfully increased the stream retention period "
-                )
-            )
+      req
+        .increaseStreamRetention(streamsRef)
+        .aggregateErrors
+        .flatTap(
+          _.fold(
+            e =>
+              logger.warn(ctx.context, e)(
+                "Increasing the stream retention period was unuccessful"
+              ),
+            _ =>
+              logger.debug(ctx.context)(
+                "Successfully increased the stream retention period "
+              )
           )
-      )
+        )
   }
 
   def describeLimits(
       context: LoggingContext
-  ): IO[Either[KinesisMockException, DescribeLimitsResponse]] =
+  ): IO[EitherResponse[DescribeLimitsResponse]] =
     logger.debug(context.context)("Processing DescribeLimits request") *>
       semaphores.describeLimits.tryAcquireRelease(
-        streamsRef.get.flatMap { streams =>
-          val response = DescribeLimitsResponse.get(config.shardLimit, streams)
-          logger.debug(context.context)("Successfully described limits") *>
-            logger
-              .trace(context.addJson("response", response.asJson).context)(
-                "Logging response"
-              )
-              .as(Right(response))
+        {
+          DescribeLimitsResponse
+            .get(config.shardLimit, streamsRef)
+            .flatMap(response =>
+              logger.debug(context.context)("Successfully described limits") *>
+                logger
+                  .trace(context.addJson("response", response.asJson).context)(
+                    "Logging response"
+                  )
+                  .as(Right(response))
+            )
         },
         logger
           .warn(context.context)("Rate limit exceeded for DescribeLimits")
@@ -334,7 +294,7 @@ class Cache private (
   def describeStream(
       req: DescribeStreamRequest,
       context: LoggingContext
-  ): IO[Either[KinesisMockException, DescribeStreamResponse]] = {
+  ): IO[EitherResponse[DescribeStreamResponse]] = {
     val ctx = context + ("streamName" -> req.streamName.streamName)
     logger.debug(ctx.context)(
       "Processing DescribeStream request"
@@ -343,29 +303,27 @@ class Cache private (
         "Logging request"
       ) *>
       semaphores.describeStream.tryAcquireRelease(
-        streamsRef.get.flatMap { streams =>
-          val response = req
-            .describeStream(streams)
-            .toEither
-            .leftMap(KinesisMockException.aggregate)
-
-          response.fold(
-            e =>
-              logger
-                .warn(ctx.context, e)(
-                  "Describing the stream was unuccessful"
-                )
-                .as(response),
-            r =>
-              logger.debug(ctx.context)(
-                "Successfully described the stream"
-              ) *> logger
-                .trace(ctx.addJson("response", r.asJson).context)(
-                  "Logging response"
-                )
-                .as(response)
-          )
-        },
+        req
+          .describeStream(streamsRef)
+          .aggregateErrors
+          .flatMap { response =>
+            response.fold(
+              e =>
+                logger
+                  .warn(ctx.context, e)(
+                    "Describing the stream was unuccessful"
+                  )
+                  .as(response),
+              r =>
+                logger.debug(ctx.context)(
+                  "Successfully described the stream"
+                ) *> logger
+                  .trace(ctx.addJson("response", r.asJson).context)(
+                    "Logging response"
+                  )
+                  .as(response)
+            )
+          },
         logger
           .warn(context.context)("Rate limit exceeded for DescribeStream")
           .as(
@@ -379,7 +337,7 @@ class Cache private (
   def describeStreamSummary(
       req: DescribeStreamSummaryRequest,
       context: LoggingContext
-  ): IO[Either[KinesisMockException, DescribeStreamSummaryResponse]] = {
+  ): IO[EitherResponse[DescribeStreamSummaryResponse]] = {
     val ctx = context + ("streamName" -> req.streamName.streamName)
     logger.debug(ctx.context)(
       "Processing DescribeStreamSummary request"
@@ -388,29 +346,27 @@ class Cache private (
         "Logging request"
       ) *>
       semaphores.describeStreamSummary.tryAcquireRelease(
-        streamsRef.get.flatMap { streams =>
-          val response = req
-            .describeStreamSummary(streams)
-            .toEither
-            .leftMap(KinesisMockException.aggregate)
-
-          response.fold(
-            e =>
-              logger
-                .warn(ctx.context, e)(
-                  "Describing the stream summary was unuccessful"
-                )
-                .as(response),
-            r =>
-              logger.debug(ctx.context)(
-                "Successfully described the stream summary"
-              ) *> logger
-                .trace(ctx.addJson("response", r.asJson).context)(
-                  "Logging response"
-                )
-                .as(response)
-          )
-        },
+        req
+          .describeStreamSummary(streamsRef)
+          .aggregateErrors
+          .flatMap(response =>
+            response.fold(
+              e =>
+                logger
+                  .warn(ctx.context, e)(
+                    "Describing the stream summary was unuccessful"
+                  )
+                  .as(response),
+              r =>
+                logger.debug(ctx.context)(
+                  "Successfully described the stream summary"
+                ) *> logger
+                  .trace(ctx.addJson("response", r.asJson).context)(
+                    "Logging response"
+                  )
+                  .as(response)
+            )
+          ),
         logger
           .warn(context.context)(
             "Rate limit exceeded for DescribeStreamSummary"
@@ -429,9 +385,8 @@ class Cache private (
       req: RegisterStreamConsumerRequest,
       context: LoggingContext
   )(implicit
-      T: Timer[IO],
-      CS: ContextShift[IO]
-  ): IO[Either[KinesisMockException, RegisterStreamConsumerResponse]] = {
+      T: Timer[IO]
+  ): IO[EitherResponse[RegisterStreamConsumerResponse]] = {
     val ctx = context + ("streamArn" -> req.streamArn)
     logger.debug(ctx.context)(
       "Processing RegisterStreamConsumer request"
@@ -440,31 +395,25 @@ class Cache private (
         "Logging request"
       ) *>
       semaphores.registerStreamConsumer.tryAcquireRelease(
-        streamsRef.get.flatMap { streams =>
-          val response = req
-            .registerStreamConsumer(streams)
-            .toEither
-            .leftMap(KinesisMockException.aggregate)
-          response
-            .fold(
-              e =>
-                logger
-                  .warn(ctx.context, e)(
-                    "Describing the stream summary was unuccessful"
-                  ),
-              r =>
-                logger.debug(ctx.context)(
-                  "Successfully described the stream summary"
-                ) *> logger
-                  .trace(ctx.addJson("response", r._2.asJson).context)(
-                    "Logging response"
-                  )
-            ) *> response
-            .traverse { case (updated, response) =>
-              streamsRef
-                .set(updated)
-                .flatMap { _ =>
-                  supervisor
+        req
+          .registerStreamConsumer(streamsRef)
+          .aggregateErrors
+          .flatMap(response =>
+            response
+              .fold(
+                e =>
+                  logger
+                    .warn(ctx.context, e)(
+                      "Describing the stream summary was unuccessful"
+                    )
+                    .as(response),
+                r =>
+                  logger.debug(ctx.context)(
+                    "Successfully described the stream summary"
+                  ) *> logger
+                    .trace(ctx.addJson("response", r.asJson).context)(
+                      "Logging response"
+                    ) *> supervisor
                     .supervise(
                       logger.debug(ctx.context)(
                         s"Delaying setting the consumer as ACTIVE for ${config.registerStreamConsumerDuration.toString}"
@@ -472,15 +421,14 @@ class Cache private (
                         IO.sleep(config.registerStreamConsumerDuration) *>
                         logger.debug(ctx.context)(
                           s"Setting consumer as ACTIVE"
-                        ) *>
-                        updated.streams.values
-                          .find(_.streamArn == req.streamArn)
-                          .traverse(stream =>
-                            streamsRef.set(
-                              updated.updateStream(
+                        ) *> streamsRef.update(x =>
+                          x.streams.values
+                            .find(_.streamArn == req.streamArn)
+                            .fold(x)(stream =>
+                              x.updateStream(
                                 stream.copy(consumers =
                                   stream.consumers ++ List(
-                                    response.consumer.consumerName -> response.consumer
+                                    r.consumer.consumerName -> r.consumer
                                       .copy(consumerStatus =
                                         ConsumerStatus.ACTIVE
                                       )
@@ -488,13 +436,12 @@ class Cache private (
                                 )
                               )
                             )
-                          )
+                        )
                     )
                     .void
-                }
-                .as(response)
-            }
-        },
+                    .as(response)
+              )
+          ),
         logger
           .warn(context.context)(
             "Rate limit exceeded for RegisterStreamConsumer"
@@ -512,10 +459,7 @@ class Cache private (
   def deregisterStreamConsumer(
       req: DeregisterStreamConsumerRequest,
       context: LoggingContext
-  )(implicit
-      T: Timer[IO],
-      CS: ContextShift[IO]
-  ): IO[Either[KinesisMockException, Unit]] = {
+  )(implicit T: Timer[IO]): IO[EitherResponse[Unit]] = {
     logger.debug(context.context)(
       "Processing DeregisterStreamConsumer request"
     ) *>
@@ -523,58 +467,51 @@ class Cache private (
         "Logging request"
       ) *>
       semaphores.deregisterStreamConsumer.tryAcquireRelease(
-        streamsRef.get.flatMap { streams =>
-          val response = req
-            .deregisterStreamConsumer(streams)
-            .toEither
-            .leftMap(KinesisMockException.aggregate)
-
-          response
-            .fold(
-              e =>
-                logger
-                  .warn(context.context, e)(
-                    "Deregistering the stream consumer was unuccessful"
-                  ),
-              _ =>
-                logger.debug(context.context)(
-                  "Successfully registered the stream consumer"
-                )
-            ) *> response.traverse { case (updated, consumer) =>
-            streamsRef
-              .set(updated)
-              .flatMap { _ =>
-                supervisor
-                  .supervise(
-                    logger.debug(context.context)(
-                      s"Delaying removing the consumer for ${config.deregisterStreamConsumerDuration.toString}"
-                    ) *>
-                      IO.sleep(config.deregisterStreamConsumerDuration) *>
+        req
+          .deregisterStreamConsumer(streamsRef)
+          .aggregateErrors
+          .flatMap(response =>
+            response
+              .fold(
+                e =>
+                  logger
+                    .warn(context.context, e)(
+                      "Deregistering the stream consumer was unuccessful"
+                    )
+                    .as(response.as(())),
+                consumer =>
+                  logger.debug(context.context)(
+                    "Successfully registered the stream consumer"
+                  ) *> supervisor
+                    .supervise(
                       logger.debug(context.context)(
-                        s"Removing the consumer"
+                        s"Delaying removing the consumer for ${config.deregisterStreamConsumerDuration.toString}"
                       ) *>
-                      updated.streams.values
-                        .find(s =>
-                          s.consumers.keys.toList
-                            .contains(consumer.consumerName)
-                        )
-                        .traverse(stream =>
-                          streamsRef.set(
-                            updated.updateStream(
-                              stream.copy(consumers =
-                                stream.consumers.filterNot {
-                                  case (consumerName, _) =>
-                                    consumerName == consumer.consumerName
-                                }
+                        IO.sleep(config.deregisterStreamConsumerDuration) *>
+                        logger.debug(context.context)(
+                          s"Removing the consumer"
+                        ) *>
+                        streamsRef.update(x =>
+                          x.streams.values
+                            .find(s =>
+                              s.consumers.keys.toList
+                                .contains(consumer.consumerName)
+                            )
+                            .fold(x)(stream =>
+                              x.updateStream(
+                                stream
+                                  .copy(consumers = stream.consumers.filterNot {
+                                    case (consumerName, _) =>
+                                      consumerName == consumer.consumerName
+                                  })
                               )
                             )
-                          )
                         )
-                  )
-                  .void
-              }
-          }
-        },
+                    )
+                    .void
+                    .as(response.as(()))
+              )
+          ),
         logger
           .warn(context.context)(
             "Rate limit exceeded for DeregisterStreamConsumer"
@@ -592,7 +529,7 @@ class Cache private (
   def describeStreamConsumer(
       req: DescribeStreamConsumerRequest,
       context: LoggingContext
-  ): IO[Either[KinesisMockException, DescribeStreamConsumerResponse]] =
+  ): IO[EitherResponse[DescribeStreamConsumerResponse]] =
     logger.debug(context.context)(
       "Processing DescribeStreamConsumer request"
     ) *>
@@ -600,29 +537,27 @@ class Cache private (
         "Logging request"
       ) *>
       semaphores.describeStreamConsumer.tryAcquireRelease(
-        streamsRef.get.flatMap { streams =>
-          val response = req
-            .describeStreamConsumer(streams)
-            .toEither
-            .leftMap(KinesisMockException.aggregate)
-
-          response.fold(
-            e =>
-              logger
-                .warn(context.context, e)(
-                  "Describing the stream consumer was unuccessful"
-                )
-                .as(response),
-            r =>
-              logger.debug(context.context)(
-                "Successfully described the stream consumer"
-              ) *> logger
-                .trace(context.addJson("response", r.asJson).context)(
-                  "Logging response"
-                )
-                .as(response)
-          )
-        },
+        req
+          .describeStreamConsumer(streamsRef)
+          .aggregateErrors
+          .flatMap(response =>
+            response.fold(
+              e =>
+                logger
+                  .warn(context.context, e)(
+                    "Describing the stream consumer was unuccessful"
+                  )
+                  .as(response),
+              r =>
+                logger.debug(context.context)(
+                  "Successfully described the stream consumer"
+                ) *> logger
+                  .trace(context.addJson("response", r.asJson).context)(
+                    "Logging response"
+                  )
+                  .as(response)
+            )
+          ),
         logger
           .warn(context.context)(
             "Rate limit exceeded for DescribeStreamConsumer"
@@ -639,7 +574,7 @@ class Cache private (
   def disableEnhancedMonitoring(
       req: DisableEnhancedMonitoringRequest,
       context: LoggingContext
-  ): IO[Either[KinesisMockException, DisableEnhancedMonitoringResponse]] = {
+  ): IO[EitherResponse[DisableEnhancedMonitoringResponse]] = {
     val ctx = context + ("streamName" -> req.streamName.streamName)
     logger.debug(ctx.context)(
       "Processing DisableEnhancedMonitoring request"
@@ -647,39 +582,33 @@ class Cache private (
       logger.trace(ctx.addJson("request", req.asJson).context)(
         "Logging request"
       ) *>
-      streamsRef.get.flatMap { streams =>
-        val response = req
-          .disableEnhancedMonitoring(streams)
-          .toEither
-          .leftMap(KinesisMockException.aggregate)
-
-        response.fold(
-          e =>
-            logger
-              .warn(context.context, e)(
-                "Disabling the enhanced monitoring was unuccessful"
-              )
-              .as(response),
-          r =>
-            logger.debug(context.context)(
-              "Successfully disabled enhanced monitoring"
-            ) *> logger
-              .trace(context.addJson("response", r._2.asJson).context)(
-                "Logging response"
-              )
-              .as(response)
+      req
+        .disableEnhancedMonitoring(streamsRef)
+        .aggregateErrors
+        .flatMap(response =>
+          response.fold(
+            e =>
+              logger
+                .warn(context.context, e)(
+                  "Disabling the enhanced monitoring was unuccessful"
+                )
+                .as(response),
+            r =>
+              logger.debug(context.context)(
+                "Successfully disabled enhanced monitoring"
+              ) *> logger
+                .trace(context.addJson("response", r.asJson).context)(
+                  "Logging response"
+                )
+                .as(response)
+          )
         )
-
-        response.traverse { case (updated, response) =>
-          streamsRef.set(updated).as(response)
-        }
-      }
   }
 
   def enableEnhancedMonitoring(
       req: EnableEnhancedMonitoringRequest,
       context: LoggingContext
-  ): IO[Either[KinesisMockException, EnableEnhancedMonitoringResponse]] = {
+  ): IO[EitherResponse[EnableEnhancedMonitoringResponse]] = {
     val ctx = context + ("streamName" -> req.streamName.streamName)
     logger.debug(ctx.context)(
       "Processing EnableEnhancedMonitoring request"
@@ -687,39 +616,33 @@ class Cache private (
       logger.trace(ctx.addJson("request", req.asJson).context)(
         "Logging request"
       ) *>
-      streamsRef.get.flatMap { streams =>
-        val response = req
-          .enableEnhancedMonitoring(streams)
-          .toEither
-          .leftMap(KinesisMockException.aggregate)
-
-        response.fold(
-          e =>
-            logger
-              .warn(context.context, e)(
-                "Enabling the enhanced monitoring was unuccessful"
-              )
-              .as(response),
-          r =>
-            logger.debug(context.context)(
-              "Successfully enabled enhanced monitoring"
-            ) *> logger
-              .trace(context.addJson("response", r._2.asJson).context)(
-                "Logging response"
-              )
-              .as(response)
+      req
+        .enableEnhancedMonitoring(streamsRef)
+        .aggregateErrors
+        .flatMap(response =>
+          response.fold(
+            e =>
+              logger
+                .warn(context.context, e)(
+                  "Enabling the enhanced monitoring was unuccessful"
+                )
+                .as(response),
+            r =>
+              logger.debug(context.context)(
+                "Successfully enabled enhanced monitoring"
+              ) *> logger
+                .trace(context.addJson("response", r.asJson).context)(
+                  "Logging response"
+                )
+                .as(response)
+          )
         )
-
-        response.traverse { case (updated, response) =>
-          streamsRef.set(updated).as(response)
-        }
-      }
   }
 
   def listShards(
       req: ListShardsRequest,
       context: LoggingContext
-  ): IO[Either[KinesisMockException, ListShardsResponse]] =
+  ): IO[EitherResponse[ListShardsResponse]] =
     logger.debug(context.context)(
       "Processing ListShards request"
     ) *>
@@ -727,29 +650,27 @@ class Cache private (
         "Logging request"
       ) *>
       semaphores.listShards.tryAcquireRelease(
-        streamsRef.get.flatMap { streams =>
-          val response = req
-            .listShards(streams)
-            .toEither
-            .leftMap(KinesisMockException.aggregate)
-
-          response.fold(
-            e =>
-              logger
-                .warn(context.context, e)(
-                  "Listing shards was unuccessful"
-                )
-                .as(response),
-            r =>
-              logger.debug(context.context)(
-                "Successfully listed shards"
-              ) *> logger
-                .trace(context.addJson("response", r.asJson).context)(
-                  "Logging response"
-                )
-                .as(response)
-          )
-        },
+        req
+          .listShards(streamsRef)
+          .aggregateErrors
+          .flatMap(response =>
+            response.fold(
+              e =>
+                logger
+                  .warn(context.context, e)(
+                    "Listing shards was unuccessful"
+                  )
+                  .as(response),
+              r =>
+                logger.debug(context.context)(
+                  "Successfully listed shards"
+                ) *> logger
+                  .trace(context.addJson("response", r.asJson).context)(
+                    "Logging response"
+                  )
+                  .as(response)
+            )
+          ),
         logger
           .warn(context.context)(
             "Rate limit exceeded for ListShards"
@@ -760,7 +681,7 @@ class Cache private (
   def listStreamConsumers(
       req: ListStreamConsumersRequest,
       context: LoggingContext
-  ): IO[Either[KinesisMockException, ListStreamConsumersResponse]] = {
+  ): IO[EitherResponse[ListStreamConsumersResponse]] = {
     val ctx = context + ("streamArn" -> req.streamArn)
     logger.debug(ctx.context)(
       "Processing ListStreamConsumers request"
@@ -769,29 +690,27 @@ class Cache private (
         "Logging request"
       ) *>
       semaphores.listStreamConsumers.tryAcquireRelease(
-        streamsRef.get.flatMap { streams =>
-          val response = req
-            .listStreamConsumers(streams)
-            .toEither
-            .leftMap(KinesisMockException.aggregate)
-
-          response.fold(
-            e =>
-              logger
-                .warn(context.context, e)(
-                  "Listing stream consumers was unuccessful"
-                )
-                .as(response),
-            r =>
-              logger.debug(context.context)(
-                "Successfully listed stream consumers"
-              ) *> logger
-                .trace(context.addJson("response", r.asJson).context)(
-                  "Logging response"
-                )
-                .as(response)
-          )
-        },
+        req
+          .listStreamConsumers(streamsRef)
+          .aggregateErrors
+          .flatMap(response =>
+            response.fold(
+              e =>
+                logger
+                  .warn(context.context, e)(
+                    "Listing stream consumers was unuccessful"
+                  )
+                  .as(response),
+              r =>
+                logger.debug(context.context)(
+                  "Successfully listed stream consumers"
+                ) *> logger
+                  .trace(context.addJson("response", r.asJson).context)(
+                    "Logging response"
+                  )
+                  .as(response)
+            )
+          ),
         logger
           .warn(ctx.context)(
             "Rate limit exceeded for ListShards"
@@ -807,7 +726,7 @@ class Cache private (
   def listStreams(
       req: ListStreamsRequest,
       context: LoggingContext
-  ): IO[Either[KinesisMockException, ListStreamsResponse]] =
+  ): IO[EitherResponse[ListStreamsResponse]] =
     logger.debug(context.context)(
       "Processing ListStreams request"
     ) *>
@@ -815,29 +734,27 @@ class Cache private (
         "Logging request"
       ) *>
       semaphores.listStreams.tryAcquireRelease(
-        streamsRef.get.flatMap { streams =>
-          val response = req
-            .listStreams(streams)
-            .toEither
-            .leftMap(KinesisMockException.aggregate)
-
-          response.fold(
-            e =>
-              logger
-                .warn(context.context, e)(
-                  "Listing streams was unuccessful"
-                )
-                .as(response),
-            r =>
-              logger.debug(context.context)(
-                "Successfully listed streams"
-              ) *> logger
-                .trace(context.addJson("response", r.asJson).context)(
-                  "Logging response"
-                )
-                .as(response)
-          )
-        },
+        req
+          .listStreams(streamsRef)
+          .aggregateErrors
+          .flatMap(response =>
+            response.fold(
+              e =>
+                logger
+                  .warn(context.context, e)(
+                    "Listing streams was unuccessful"
+                  )
+                  .as(response),
+              r =>
+                logger.debug(context.context)(
+                  "Successfully listed streams"
+                ) *> logger
+                  .trace(context.addJson("response", r.asJson).context)(
+                    "Logging response"
+                  )
+                  .as(response)
+            )
+          ),
         logger
           .warn(context.context)(
             "Rate limit exceeded for ListStreams"
@@ -852,7 +769,7 @@ class Cache private (
   def listTagsForStream(
       req: ListTagsForStreamRequest,
       context: LoggingContext
-  ): IO[Either[KinesisMockException, ListTagsForStreamResponse]] = {
+  ): IO[EitherResponse[ListTagsForStreamResponse]] = {
     val ctx = context + ("streamName" -> req.streamName.streamName)
     logger.debug(ctx.context)(
       "Processing ListTagsForStream request"
@@ -861,29 +778,27 @@ class Cache private (
         "Logging request"
       ) *>
       semaphores.listTagsForStream.tryAcquireRelease(
-        streamsRef.get.flatMap { streams =>
-          val response = req
-            .listTagsForStream(streams)
-            .toEither
-            .leftMap(KinesisMockException.aggregate)
-
-          response.fold(
-            e =>
-              logger
-                .warn(context.context, e)(
-                  "Listing tags for stream was unuccessful"
-                )
-                .as(response),
-            r =>
-              logger.debug(context.context)(
-                "Successfully listed tags for stream"
-              ) *> logger
-                .trace(context.addJson("response", r.asJson).context)(
-                  "Logging response"
-                )
-                .as(response)
-          )
-        },
+        req
+          .listTagsForStream(streamsRef)
+          .aggregateErrors
+          .flatMap(response =>
+            response.fold(
+              e =>
+                logger
+                  .warn(context.context, e)(
+                    "Listing tags for stream was unuccessful"
+                  )
+                  .as(response),
+              r =>
+                logger.debug(context.context)(
+                  "Successfully listed tags for stream"
+                ) *> logger
+                  .trace(context.addJson("response", r.asJson).context)(
+                    "Logging response"
+                  )
+                  .as(response)
+            )
+          ),
         logger
           .warn(ctx.context)(
             "Rate limit exceeded for ListTagsForStream"
@@ -899,10 +814,7 @@ class Cache private (
   def startStreamEncryption(
       req: StartStreamEncryptionRequest,
       context: LoggingContext
-  )(implicit
-      T: Timer[IO],
-      CS: ContextShift[IO]
-  ): IO[Either[KinesisMockException, Unit]] = {
+  )(implicit T: Timer[IO]): IO[EitherResponse[Unit]] = {
     val ctx = context + ("streamName" -> req.streamName.streamName)
     logger.debug(ctx.context)(
       "Processing StartStreamEncryption request"
@@ -910,53 +822,46 @@ class Cache private (
       logger.trace(ctx.addJson("request", req.asJson).context)(
         "Logging request"
       ) *>
-      streamsRef.get.flatMap { streams =>
-        val response = req
-          .startStreamEncryption(streams)
-          .toEither
-          .leftMap(KinesisMockException.aggregate)
-
-        response
-          .fold(
-            e =>
-              logger
-                .warn(ctx.context, e)(
-                  "Starting stream encryption was unuccessful"
-                ),
-            _ =>
-              logger.debug(ctx.context)(
-                "Successfully started stream encryption"
-              )
-          ) *> response.traverse(updated =>
-          streamsRef.set(updated) *>
-            supervisor
-              .supervise(
-                logger.debug(context.context)(
-                  s"Delaying setting the stream to active for ${config.startStreamEncryptionDuration.toString}"
-                ) *>
-                  IO.sleep(config.startStreamEncryptionDuration) *>
-                  logger.debug(context.context)(
-                    s"Setting the stream to active"
-                  ) *>
-                  streamsRef
-                    .set(
-                      updated.findAndUpdateStream(req.streamName)(x =>
-                        x.copy(streamStatus = StreamStatus.ACTIVE)
-                      )
-                    )
-              )
-              .void
+      req
+        .startStreamEncryption(streamsRef)
+        .aggregateErrors
+        .flatMap(response =>
+          response
+            .fold(
+              e =>
+                logger
+                  .warn(ctx.context, e)(
+                    "Starting stream encryption was unuccessful"
+                  )
+                  .as(response),
+              _ =>
+                logger.debug(ctx.context)(
+                  "Successfully started stream encryption"
+                ) *> supervisor
+                  .supervise(
+                    logger.debug(context.context)(
+                      s"Delaying setting the stream to active for ${config.startStreamEncryptionDuration.toString}"
+                    ) *>
+                      IO.sleep(config.startStreamEncryptionDuration) *>
+                      logger.debug(context.context)(
+                        s"Setting the stream to active"
+                      ) *>
+                      streamsRef
+                        .update(updated =>
+                          updated.findAndUpdateStream(req.streamName)(x =>
+                            x.copy(streamStatus = StreamStatus.ACTIVE)
+                          )
+                        )
+                  )
+                  .as(response)
+            )
         )
-      }
   }
 
   def stopStreamEncryption(
       req: StopStreamEncryptionRequest,
       context: LoggingContext
-  )(implicit
-      T: Timer[IO],
-      CS: ContextShift[IO]
-  ): IO[Either[KinesisMockException, Unit]] = {
+  )(implicit T: Timer[IO]): IO[EitherResponse[Unit]] = {
     val ctx = context + ("streamName" -> req.streamName.streamName)
     logger.debug(ctx.context)(
       "Processing StopStreamEncryption request"
@@ -964,50 +869,49 @@ class Cache private (
       logger.trace(ctx.addJson("request", req.asJson).context)(
         "Logging request"
       ) *>
-      streamsRef.get.flatMap { streams =>
-        val response = req
-          .stopStreamEncryption(streams)
-          .toEither
-          .leftMap(KinesisMockException.aggregate)
-
-        response
-          .fold(
-            e =>
-              logger
-                .warn(ctx.context, e)(
-                  "Stopping stream encryption was unuccessful"
-                ),
-            _ =>
-              logger.debug(ctx.context)(
-                "Successfully stopped stream encryption"
-              )
-          ) *> response.traverse(updated =>
-          streamsRef.set(updated) *>
-            supervisor
-              .supervise(
-                logger.debug(context.context)(
-                  s"Delaying setting the stream to active for ${config.stopStreamEncryptionDuration.toString}"
+      req
+        .stopStreamEncryption(streamsRef)
+        .aggregateErrors
+        .flatMap(response =>
+          response
+            .fold(
+              e =>
+                logger
+                  .warn(ctx.context, e)(
+                    "Stopping stream encryption was unuccessful"
+                  )
+                  .as(response),
+              _ =>
+                logger.debug(ctx.context)(
+                  "Successfully stopped stream encryption"
                 ) *>
-                  IO.sleep(config.stopStreamEncryptionDuration) *>
-                  logger.debug(context.context)(
-                    s"Setting the stream to active"
-                  ) *>
-                  streamsRef
-                    .set(
-                      updated.findAndUpdateStream(req.streamName)(x =>
-                        x.copy(streamStatus = StreamStatus.ACTIVE)
-                      )
+                  supervisor
+                    .supervise(
+                      logger.debug(context.context)(
+                        s"Delaying setting the stream to active for ${config.stopStreamEncryptionDuration.toString}"
+                      ) *>
+                        IO.sleep(config.stopStreamEncryptionDuration) *>
+                        logger.debug(context.context)(
+                          s"Setting the stream to active"
+                        ) *>
+                        streamsRef
+                          .update(updated =>
+                            updated.findAndUpdateStream(req.streamName)(x =>
+                              x.copy(streamStatus = StreamStatus.ACTIVE)
+                            )
+                          )
                     )
-              )
-              .void
+                    .void
+                    .as(response)
+            )
         )
-      }
+
   }
 
   def getShardIterator(
       req: GetShardIteratorRequest,
       context: LoggingContext
-  ): IO[Either[KinesisMockException, GetShardIteratorResponse]] = {
+  ): IO[EitherResponse[GetShardIteratorResponse]] = {
     val ctx = context + ("streamName" -> req.streamName.streamName)
     logger.debug(ctx.context)(
       "Processing GetShardIterator request"
@@ -1015,82 +919,77 @@ class Cache private (
       logger.trace(ctx.addJson("request", req.asJson).context)(
         "Logging request"
       ) *>
-      streamsRef.get.flatMap { streams =>
-        val response = req
-          .getShardIterator(streams)
-          .toEither
-          .leftMap(KinesisMockException.aggregate)
+      req
+        .getShardIterator(streamsRef)
+        .aggregateErrors
+        .flatMap(response =>
+          response
+            .fold(
+              e =>
+                logger
+                  .warn(ctx.context, e)(
+                    "Getting the shard iterator was unuccessful"
+                  )
+                  .as(response),
+              r =>
+                logger.debug(ctx.context)(
+                  "Successfully got the shard iterator"
+                ) *> logger
+                  .trace(ctx.addJson("response", r.asJson).context)(
+                    "Logging response"
+                  )
+                  .as(response)
+            )
+        )
 
-        response
-          .fold(
-            e =>
-              logger
-                .warn(ctx.context, e)(
-                  "Getting the shard iterator was unuccessful"
-                )
-                .as(response),
-            r =>
-              logger.debug(ctx.context)(
-                "Successfully got the shard iterator"
-              ) *> logger
-                .trace(ctx.addJson("response", r.asJson).context)(
-                  "Logging response"
-                )
-                .as(response)
-          )
-      }
   }
   def getRecords(
       req: GetRecordsRequest,
       context: LoggingContext
-  ): IO[Either[KinesisMockException, GetRecordsResponse]] =
+  ): IO[EitherResponse[GetRecordsResponse]] =
     logger.debug(context.context)(
       "Processing GetRecords request"
     ) *>
       logger.trace(context.addJson("request", req.asJson).context)(
         "Logging request"
       ) *>
-      streamsRef.get.flatMap { streams =>
-        val response = req
-          .getRecords(streams)
-          .toEither
-          .leftMap(KinesisMockException.aggregate)
-
-        response
-          .fold(
-            e =>
-              logger
-                .warn(context.context, e)(
-                  "Getting records was unuccessful"
-                )
-                .as(response),
-            r =>
-              logger.debug(context.context)(
-                "Successfully got records"
-              ) *> logger
-                .trace(context.addJson("response", r.asJson).context)(
-                  "Logging response"
-                )
-                .as(response)
-          )
-      }
+      req
+        .getRecords(streamsRef)
+        .aggregateErrors
+        .flatMap(response =>
+          response
+            .fold(
+              e =>
+                logger
+                  .warn(context.context, e)(
+                    "Getting records was unuccessful"
+                  )
+                  .as(response),
+              r =>
+                logger.debug(context.context)(
+                  "Successfully got records"
+                ) *> logger
+                  .trace(context.addJson("response", r.asJson).context)(
+                    "Logging response"
+                  )
+                  .as(response)
+            )
+        )
 
   def putRecord(
       req: PutRecordRequest,
       context: LoggingContext
-  ): IO[Either[KinesisMockException, PutRecordResponse]] = {
+  ): IO[EitherResponse[PutRecordResponse]] = {
     val ctx = context + ("streamName" -> req.streamName.streamName)
     for {
       _ <- logger.debug(ctx.context)("Processing PutRecord request")
       _ <- logger.trace(context.addJson("request", req.asJson).context)(
         "Logging request"
       )
-      streams <- streamsRef.get
-      shardSemaphores <- shardsSemaphoresRef.get
-      put <- req
-        .putRecord(streams, shardSemaphores)
-        .map(_.toEither.leftMap(KinesisMockException.aggregate))
-      _ <- put.fold(
+      res <- req
+        .putRecord(streamsRef, shardSemaphoresRef)
+        .aggregateErrors
+      _ <- res.fold(
         e =>
           logger
             .warn(ctx.context, e)(
@@ -1100,12 +999,10 @@ class Cache private (
           logger.debug(ctx.context)(
             "Successfully put record"
           ) *> logger
-            .trace(ctx.addJson("response", r._2.asJson).context)(
+            .trace(ctx.addJson("response", r.asJson).context)(
               "Logging response"
             )
       )
-      _ <- put.traverse { case (updated, _) => streamsRef.set(updated) }
-      res = put.map(_._2)
     } yield res
   }
 
@@ -1114,19 +1011,17 @@ class Cache private (
       context: LoggingContext
   )(implicit
       P: Parallel[IO]
-  ): IO[Either[KinesisMockException, PutRecordsResponse]] = {
+  ): IO[EitherResponse[PutRecordsResponse]] = {
     val ctx = context + ("streamName" -> req.streamName.streamName)
     for {
       _ <- logger.debug(ctx.context)("Processing PutRecords request")
       _ <- logger.trace(context.addJson("request", req.asJson).context)(
         "Logging request"
       )
-      streams <- streamsRef.get
-      shardSemaphores <- shardsSemaphoresRef.get
-      put <- req
-        .putRecords(streams, shardSemaphores)
-        .map(_.toEither.leftMap(KinesisMockException.aggregate))
-      _ <- put.fold(
+      res <- req
+        .putRecords(streamsRef, shardSemaphoresRef)
+        .aggregateErrors
+      _ <- res.fold(
         e =>
           logger
             .warn(ctx.context, e)(
@@ -1136,12 +1031,10 @@ class Cache private (
           logger.debug(ctx.context)(
             "Successfully put records"
           ) *> logger
-            .trace(ctx.addJson("response", r._2.asJson).context)(
+            .trace(ctx.addJson("response", r.asJson).context)(
               "Logging response"
             )
       )
-      _ <- put.traverse { case (updated, _) => streamsRef.set(updated) }
-      res = put.map(_._2)
     } yield res
   }
 
@@ -1151,7 +1044,7 @@ class Cache private (
   )(implicit
       T: Timer[IO],
       CS: ContextShift[IO]
-  ): IO[Either[KinesisMockException, Unit]] = {
+  ): IO[EitherResponse[Unit]] = {
     val ctx = context + ("streamName" -> req.streamName.streamName)
     logger.debug(ctx.context)(
       "Processing MergeShards request"
@@ -1161,11 +1054,9 @@ class Cache private (
       ) *>
       semaphores.mergeShards.tryAcquireRelease(
         for {
-          streams <- streamsRef.get
-          shardSemaphores <- shardsSemaphoresRef.get
           result <- req
-            .mergeShards(streams, shardSemaphores)
-            .map(_.toEither.leftMap(KinesisMockException.aggregate))
+            .mergeShards(streamsRef, shardSemaphoresRef)
+            .aggregateErrors
           _ <- result.fold(
             e =>
               logger
@@ -1177,32 +1068,24 @@ class Cache private (
                 "Successfully merged shards"
               )
           )
-          res <- result.traverse { case (updated, newShardsSemaphoreKey) =>
-            streamsRef.set(updated) *>
-              Semaphore[IO](1).flatMap(semaphore =>
-                shardsSemaphoresRef.update(shardsSemaphore =>
-                  shardsSemaphore ++ List(newShardsSemaphoreKey -> semaphore)
-                )
+          _ <- supervisor
+            .supervise(
+              logger.debug(context.context)(
+                s"Delaying setting the stream to active for ${config.mergeShardsDuration.toString}"
               ) *>
-              supervisor
-                .supervise(
-                  logger.debug(context.context)(
-                    s"Delaying setting the stream to active for ${config.mergeShardsDuration.toString}"
-                  ) *>
-                    IO.sleep(config.mergeShardsDuration) *>
-                    logger.debug(context.context)(
-                      s"Setting the stream to active"
-                    ) *>
-                    streamsRef
-                      .set(
-                        updated.findAndUpdateStream(req.streamName)(x =>
-                          x.copy(streamStatus = StreamStatus.ACTIVE)
-                        )
-                      )
-                )
-                .void
-          }
-        } yield res,
+                IO.sleep(config.mergeShardsDuration) *>
+                logger.debug(context.context)(
+                  s"Setting the stream to active"
+                ) *>
+                streamsRef
+                  .update(updated =>
+                    updated.findAndUpdateStream(req.streamName)(x =>
+                      x.copy(streamStatus = StreamStatus.ACTIVE)
+                    )
+                  )
+            )
+            .void
+        } yield result,
         logger
           .warn(ctx.context)(
             "Rate limit exceeded for MergeShards"
@@ -1217,7 +1100,7 @@ class Cache private (
   )(implicit
       T: Timer[IO],
       CS: ContextShift[IO]
-  ): IO[Either[KinesisMockException, Unit]] = {
+  ): IO[EitherResponse[Unit]] = {
     val ctx = context + ("streamName" -> req.streamName.streamName)
     logger.debug(ctx.context)(
       "Processing SplitShard request"
@@ -1227,11 +1110,9 @@ class Cache private (
       ) *>
       semaphores.splitShard.tryAcquireRelease(
         for {
-          streams <- streamsRef.get
-          shardSemaphores <- shardsSemaphoresRef.get
           result <- req
-            .splitShard(streams, shardSemaphores, config.shardLimit)
-            .map(_.toEither.leftMap(KinesisMockException.aggregate))
+            .splitShard(streamsRef, shardSemaphoresRef, config.shardLimit)
+            .aggregateErrors
           _ <- result.fold(
             e =>
               logger
@@ -1243,34 +1124,24 @@ class Cache private (
                 "Successfully split shard"
               )
           )
-          res <- result.traverse { case (updated, newShardsSemaphoreKeys) =>
-            streamsRef.set(updated) *>
-              Semaphore[IO](1)
-                .flatMap(x => Semaphore[IO](1).map(y => List(x, y)))
-                .flatMap(semaphores =>
-                  shardsSemaphoresRef.update(shardsSemaphore =>
-                    shardsSemaphore ++ newShardsSemaphoreKeys.zip(semaphores)
-                  )
+          _ <- supervisor
+            .supervise(
+              logger.debug(context.context)(
+                s"Delaying setting the stream to active for ${config.splitShardDuration.toString}"
+              ) *>
+                IO.sleep(config.splitShardDuration) *>
+                logger.debug(context.context)(
+                  s"Setting the stream to active"
                 ) *>
-              supervisor
-                .supervise(
-                  logger.debug(context.context)(
-                    s"Delaying setting the stream to active for ${config.splitShardDuration.toString}"
-                  ) *>
-                    IO.sleep(config.splitShardDuration) *>
-                    logger.debug(context.context)(
-                      s"Setting the stream to active"
-                    ) *>
-                    streamsRef
-                      .set(
-                        updated.findAndUpdateStream(req.streamName)(x =>
-                          x.copy(streamStatus = StreamStatus.ACTIVE)
-                        )
-                      )
-                )
-                .void
-          }
-        } yield res,
+                streamsRef
+                  .update(updated =>
+                    updated.findAndUpdateStream(req.streamName)(x =>
+                      x.copy(streamStatus = StreamStatus.ACTIVE)
+                    )
+                  )
+            )
+            .void
+        } yield result,
         logger
           .warn(ctx.context)(
             "Rate limit exceeded for MergeShards"
@@ -1285,7 +1156,7 @@ class Cache private (
   )(implicit
       T: Timer[IO],
       CS: ContextShift[IO]
-  ): IO[Either[KinesisMockException, Unit]] = {
+  ): IO[EitherResponse[Unit]] = {
     val ctx = context + ("streamName" -> req.streamName.streamName)
     logger.debug(ctx.context)(
       "Processing UpdateShardCount request"
@@ -1293,11 +1164,9 @@ class Cache private (
       logger.trace(ctx.addJson("request", req.asJson).context)(
         "Logging request"
       ) *> (for {
-        streams <- streamsRef.get
-        shardSemaphores <- shardsSemaphoresRef.get
         result <- req
-          .updateShardCount(streams, shardSemaphores, config.shardLimit)
-          .map(_.toEither.leftMap(KinesisMockException.aggregate))
+          .updateShardCount(streamsRef, shardSemaphoresRef, config.shardLimit)
+          .aggregateErrors
         _ <- result.fold(
           e =>
             logger
@@ -1309,34 +1178,24 @@ class Cache private (
               "Successfully updated shard count"
             )
         )
-        res <- result.traverse { case (updated, newShardsSemaphoreKeys) =>
-          streamsRef.set(updated) *>
-            Semaphore[IO](1)
-              .flatMap(x => Semaphore[IO](1).map(y => List(x, y)))
-              .flatMap(semaphores =>
-                shardsSemaphoresRef.update(shardsSemaphore =>
-                  shardsSemaphore ++ newShardsSemaphoreKeys.zip(semaphores)
-                )
+        _ <- supervisor
+          .supervise(
+            logger.debug(context.context)(
+              s"Delaying setting the stream to active for ${config.updateShardCountDuration.toString}"
+            ) *>
+              IO.sleep(config.updateShardCountDuration) *>
+              logger.debug(context.context)(
+                s"Setting the stream to active"
               ) *>
-            supervisor
-              .supervise(
-                logger.debug(context.context)(
-                  s"Delaying setting the stream to active for ${config.updateShardCountDuration.toString}"
-                ) *>
-                  IO.sleep(config.updateShardCountDuration) *>
-                  logger.debug(context.context)(
-                    s"Setting the stream to active"
-                  ) *>
-                  streamsRef
-                    .set(
-                      updated.findAndUpdateStream(req.streamName)(x =>
-                        x.copy(streamStatus = StreamStatus.ACTIVE)
-                      )
-                    )
-              )
-              .void
-        }
-      } yield res)
+              streamsRef
+                .update(updated =>
+                  updated.findAndUpdateStream(req.streamName)(x =>
+                    x.copy(streamStatus = StreamStatus.ACTIVE)
+                  )
+                )
+          )
+          .void
+      } yield result)
   }
 
 }
@@ -1346,13 +1205,13 @@ object Cache {
       config: CacheConfig
   )(implicit C: Concurrent[IO], P: Parallel[IO]): IO[Cache] = for {
     ref <- Ref.of[IO, Streams](Streams.empty)
-    shardsSemaphoresRef <- Ref.of[IO, Map[ShardSemaphoresKey, Semaphore[IO]]](
+    shardSemaphoresRef <- Ref.of[IO, Map[ShardSemaphoresKey, Semaphore[IO]]](
       Map.empty
     )
     semaphores <- CacheSemaphores.create
     supervisorResource = Supervisor[IO]
     cache <- supervisorResource.use(supervisor =>
-      IO(new Cache(ref, shardsSemaphoresRef, semaphores, config, supervisor))
+      IO(new Cache(ref, shardSemaphoresRef, semaphores, config, supervisor))
     )
   } yield cache
 }

--- a/src/main/scala/kinesis/mock/models/SequenceNumber.scala
+++ b/src/main/scala/kinesis/mock/models/SequenceNumber.scala
@@ -6,7 +6,6 @@ import scala.util.{Success, Try}
 import java.time.Instant
 
 import cats.data.Validated._
-import cats.data._
 import cats.kernel.Eq
 import cats.syntax.all._
 import io.circe._
@@ -22,7 +21,7 @@ final case class SequenceNumber(value: String) {
         SequenceNumber.shardEndNumber
     }
 
-  def parse: ValidatedNel[KinesisMockException, SequenceNumberParseResult] = {
+  def parse: ValidatedResponse[SequenceNumberParseResult] = {
     value match {
       case x if SequenceNumberConstant.withNameOption(x).nonEmpty =>
         Valid(SequenceNumberConstantResult(SequenceNumberConstant.withName(x)))

--- a/src/main/scala/kinesis/mock/models/ShardIterator.scala
+++ b/src/main/scala/kinesis/mock/models/ShardIterator.scala
@@ -7,7 +7,6 @@ import java.time.Instant
 import java.util.Base64
 
 import cats.data.Validated._
-import cats.data._
 import cats.kernel.Eq
 import cats.syntax.all._
 import io.circe._
@@ -18,7 +17,7 @@ import javax.xml.bind.DatatypeConverter
 import kinesis.mock.validations.CommonValidations
 
 final case class ShardIterator(value: String) {
-  def parse: ValidatedNel[KinesisMockException, ShardIteratorParts] = {
+  def parse: ValidatedResponse[ShardIteratorParts] = {
     val cipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
     val decoded = Base64.getDecoder.decode(value)
 

--- a/src/main/scala/kinesis/mock/package.scala
+++ b/src/main/scala/kinesis/mock/package.scala
@@ -1,0 +1,8 @@
+package kinesis
+
+import cats.data.ValidatedNel
+
+package object mock {
+  type ValidatedResponse[A] = ValidatedNel[KinesisMockException, A]
+  type EitherResponse[A] = Either[KinesisMockException, A]
+}

--- a/src/main/scala/kinesis/mock/syntax/io.scala
+++ b/src/main/scala/kinesis/mock/syntax/io.scala
@@ -1,0 +1,23 @@
+package kinesis.mock
+package syntax
+
+import cats.effect.IO
+import cats.syntax.all._
+
+object io extends KinesisMockIOSyntax
+
+trait KinesisMockIOSyntax {
+  implicit def toKinesisMockIOValidatedResultOps[A](
+      io: IO[ValidatedResponse[A]]
+  ): KinesisMockIOSyntax.KiensisMockIOValidatedResultOps[A] =
+    new KinesisMockIOSyntax.KiensisMockIOValidatedResultOps(io)
+}
+
+object KinesisMockIOSyntax {
+  final class KiensisMockIOValidatedResultOps[A](
+      private val io: IO[ValidatedResponse[A]]
+  ) extends AnyVal {
+    def aggregateErrors: IO[EitherResponse[A]] =
+      io.map(_.toEither.leftMap(KinesisMockException.aggregate))
+  }
+}

--- a/src/test/scala/kinesis/mock/api/DeleteStreamTests.scala
+++ b/src/test/scala/kinesis/mock/api/DeleteStreamTests.scala
@@ -2,71 +2,100 @@ package kinesis.mock.api
 
 import scala.collection.SortedMap
 
+import cats.effect.IO
+import cats.effect.concurrent.{Ref, Semaphore}
+import cats.syntax.all._
 import enumeratum.scalacheck._
-import org.scalacheck.Prop._
+import org.scalacheck.effect.PropF
 
 import kinesis.mock.instances.arbitrary._
 import kinesis.mock.models._
 
-class DeleteStreamTests extends munit.ScalaCheckSuite {
-  property("It should delete a stream")(forAll {
+class DeleteStreamTests
+    extends munit.CatsEffectSuite
+    with munit.ScalaCheckEffectSuite {
+  test("It should delete a stream")(PropF.forAllF {
     (
         streamName: StreamName,
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, _) =
+      val (streams, shardSemaphoresKeys) =
         Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
       val asActive = streams.findAndUpdateStream(streamName)(x =>
         x.copy(streamStatus = StreamStatus.ACTIVE)
       )
 
-      val req = DeleteStreamRequest(streamName, None)
-      val res = req.deleteStream(asActive)
-
-      (res.isValid && res.exists { case (s, _) =>
-        s.streams
+      for {
+        streamsRef <- Ref.of[IO, Streams](asActive)
+        semaphores <- shardSemaphoresKeys
+          .traverse(key => Semaphore[IO](1).map(s => key -> s))
+          .map(_.toMap)
+        shardSemaphoresRef <- Ref
+          .of[IO, Map[ShardSemaphoresKey, Semaphore[IO]]](semaphores)
+        req = DeleteStreamRequest(streamName, None)
+        res <- req.deleteStream(streamsRef, shardSemaphoresRef)
+        s <- streamsRef.get
+        sems <- shardSemaphoresRef.get
+      } yield assert(
+        res.isValid && s.streams
           .get(streamName)
-          .exists(_.streamStatus == StreamStatus.DELETING)
-      }) :| s"req: $req\nres: $res\nstreams: $asActive"
+          .exists(_.streamStatus == StreamStatus.DELETING) && sems.isEmpty,
+        s"req: $req\nres: $res\nstreams: $asActive"
+      )
   })
 
-  property("It should reject when the stream doesn't exist")(forAll {
+  test("It should reject when the stream doesn't exist")(PropF.forAllF {
     streamName: StreamName =>
       val streams = Streams.empty
 
-      val req = DeleteStreamRequest(streamName, None)
-      val res = req.deleteStream(streams)
-
-      res.isInvalid :| s"req: $req\nres: $res\nstreams: $streams"
+      for {
+        streamsRef <- Ref.of[IO, Streams](streams)
+        shardSemaphoresRef <- Ref
+          .of[IO, Map[ShardSemaphoresKey, Semaphore[IO]]](Map.empty)
+        req = DeleteStreamRequest(streamName, None)
+        res <- req.deleteStream(streamsRef, shardSemaphoresRef)
+      } yield assert(
+        res.isInvalid,
+        s"req: $req\nres: $res\nstreams: $streams"
+      )
   })
 
-  property("It should reject when the stream is not active")(forAll {
+  test("It should reject when the stream is not active")(PropF.forAllF {
     (
         streamName: StreamName,
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, _) =
+      val (streams, shardSemaphoresKeys) =
         Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
-      val req = DeleteStreamRequest(streamName, None)
-      val res = req.deleteStream(streams)
-
-      res.isInvalid :| s"req: $req\nres: $res\nstreams: $streams"
+      for {
+        streamsRef <- Ref.of[IO, Streams](streams)
+        semaphores <- shardSemaphoresKeys
+          .traverse(key => Semaphore[IO](1).map(s => key -> s))
+          .map(_.toMap)
+        shardSemaphoresRef <- Ref
+          .of[IO, Map[ShardSemaphoresKey, Semaphore[IO]]](semaphores)
+        req = DeleteStreamRequest(streamName, None)
+        res <- req.deleteStream(streamsRef, shardSemaphoresRef)
+      } yield assert(
+        res.isInvalid,
+        s"req: $req\nres: $res\nstreams: $streams"
+      )
   })
 
-  property(
+  test(
     "It should reject when the stream has consumes and enforceConsumerDeletion is true"
-  )(forAll {
+  )(PropF.forAllF {
     (
         streamName: StreamName,
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId,
         consumerName: ConsumerName
     ) =>
-      val (streams, _) =
+      val (streams, shardSemaphoresKeys) =
         Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
       val withConsumers = streams.findAndUpdateStream(streamName)(x =>
@@ -75,9 +104,18 @@ class DeleteStreamTests extends munit.ScalaCheckSuite {
         )
       )
 
-      val req = DeleteStreamRequest(streamName, Some(true))
-      val res = req.deleteStream(withConsumers)
-
-      res.isInvalid :| s"req: $req\nres: $res\nstreams: $streams"
+      for {
+        streamsRef <- Ref.of[IO, Streams](withConsumers)
+        semaphores <- shardSemaphoresKeys
+          .traverse(key => Semaphore[IO](1).map(s => key -> s))
+          .map(_.toMap)
+        shardSemaphoresRef <- Ref
+          .of[IO, Map[ShardSemaphoresKey, Semaphore[IO]]](semaphores)
+        req = DeleteStreamRequest(streamName, None)
+        res <- req.deleteStream(streamsRef, shardSemaphoresRef)
+      } yield assert(
+        res.isInvalid,
+        s"req: $req\nres: $res\nstreams: $streams"
+      )
   })
 }

--- a/src/test/scala/kinesis/mock/api/MergeShardsTests.scala
+++ b/src/test/scala/kinesis/mock/api/MergeShardsTests.scala
@@ -2,7 +2,7 @@ package kinesis.mock
 package api
 
 import cats.effect._
-import cats.effect.concurrent.Semaphore
+import cats.effect.concurrent.{Ref, Semaphore}
 import cats.syntax.all._
 import enumeratum.scalacheck._
 import org.scalacheck.effect.PropF
@@ -30,30 +30,32 @@ class MergeShardsTests
       val adjacentShardToMerge =
         active.streams(streamName).shards.keys.toList(1)
 
-      val req =
-        MergeShardsRequest(
+      for {
+        streamsRef <- Ref.of[IO, Streams](active)
+        req = MergeShardsRequest(
           adjacentShardToMerge.shardId.shardId,
           shardToMerge.shardId.shardId,
           streamName
         )
-
-      for {
         shardSemaphores <- shardSemaphoreKeys
           .traverse(k => Semaphore[IO](1).map(s => k -> s))
           .map(_.toMap)
-        res <- req.mergeShards(active, shardSemaphores)
+        shardSemaphoresRef <- Ref
+          .of[IO, Map[ShardSemaphoresKey, Semaphore[IO]]](
+            shardSemaphores
+          )
+        res <- req.mergeShards(streamsRef, shardSemaphoresRef)
+        s <- streamsRef.get
       } yield assert(
-        res.isValid && res.exists { case (resultStreams, _) =>
-          resultStreams.streams.get(streamName).exists { stream =>
-            stream.shards.keys.toList.exists(shard =>
-              shard.adjacentParentShardId
-                .contains(adjacentShardToMerge.shardId.shardId) &&
-                shard.parentShardId.contains(shardToMerge.shardId.shardId)
-            ) && stream.streamStatus == StreamStatus.UPDATING
-          }
+        res.isValid && s.streams.get(streamName).exists { stream =>
+          stream.shards.keys.toList.exists(shard =>
+            shard.adjacentParentShardId
+              .contains(adjacentShardToMerge.shardId.shardId) &&
+              shard.parentShardId.contains(shardToMerge.shardId.shardId)
+          ) && stream.streamStatus == StreamStatus.UPDATING
         },
         s"req: $req\n" +
-          s"resShards: ${res.map(_._1.streams(streamName).shards.keys.map(_.shardId))}\n" +
+          s"resShards: ${s.streams(streamName).shards.keys.map(_.shardId)}\n" +
           s"parentHashKeyRange:${shardToMerge.hashKeyRange}\n" +
           s"adjacentHashKeyRange:${adjacentShardToMerge.hashKeyRange}"
       )
@@ -81,10 +83,15 @@ class MergeShardsTests
         )
 
       for {
+        streamsRef <- Ref.of[IO, Streams](streams)
         shardSemaphores <- shardSemaphoreKeys
           .traverse(k => Semaphore[IO](1).map(s => k -> s))
           .map(_.toMap)
-        res <- req.mergeShards(streams, shardSemaphores)
+        shardSemaphoresRef <- Ref
+          .of[IO, Map[ShardSemaphoresKey, Semaphore[IO]]](
+            shardSemaphores
+          )
+        res <- req.mergeShards(streamsRef, shardSemaphoresRef)
       } yield assert(
         res.isInvalid,
         s"req: $req\nres: $res"
@@ -123,10 +130,15 @@ class MergeShardsTests
         )
 
       for {
+        streamsRef <- Ref.of[IO, Streams](active)
         shardSemaphores <- shardSemaphoreKeys
           .traverse(k => Semaphore[IO](1).map(s => k -> s))
           .map(_.toMap)
-        res <- req.mergeShards(active, shardSemaphores)
+        shardSemaphoresRef <- Ref
+          .of[IO, Map[ShardSemaphoresKey, Semaphore[IO]]](
+            shardSemaphores
+          )
+        res <- req.mergeShards(streamsRef, shardSemaphoresRef)
       } yield assert(
         res.isInvalid,
         s"req: $req\nres: $res"
@@ -165,10 +177,15 @@ class MergeShardsTests
         )
 
       for {
+        streamsRef <- Ref.of[IO, Streams](active)
         shardSemaphores <- shardSemaphoreKeys
           .traverse(k => Semaphore[IO](1).map(s => k -> s))
           .map(_.toMap)
-        res <- req.mergeShards(active, shardSemaphores)
+        shardSemaphoresRef <- Ref
+          .of[IO, Map[ShardSemaphoresKey, Semaphore[IO]]](
+            shardSemaphores
+          )
+        res <- req.mergeShards(streamsRef, shardSemaphoresRef)
       } yield assert(
         res.isInvalid,
         s"req: $req\nres: $res"
@@ -199,10 +216,15 @@ class MergeShardsTests
         )
 
       for {
+        streamsRef <- Ref.of[IO, Streams](active)
         shardSemaphores <- shardSemaphoreKeys
           .traverse(k => Semaphore[IO](1).map(s => k -> s))
           .map(_.toMap)
-        res <- req.mergeShards(active, shardSemaphores)
+        shardSemaphoresRef <- Ref
+          .of[IO, Map[ShardSemaphoresKey, Semaphore[IO]]](
+            shardSemaphores
+          )
+        res <- req.mergeShards(streamsRef, shardSemaphoresRef)
       } yield assert(
         res.isInvalid,
         s"req: $req\nres: $res"

--- a/src/test/scala/kinesis/mock/api/SplitShardTests.scala
+++ b/src/test/scala/kinesis/mock/api/SplitShardTests.scala
@@ -2,7 +2,7 @@ package kinesis.mock
 package api
 
 import cats.effect._
-import cats.effect.concurrent.Semaphore
+import cats.effect.concurrent.{Ref, Semaphore}
 import cats.syntax.all._
 import enumeratum.scalacheck._
 import org.scalacheck.Gen
@@ -46,20 +46,24 @@ class SplitShardTests
         )
 
       for {
+        streamsRef <- Ref.of[IO, Streams](active)
         shardSemaphores <- shardSemaphoreKeys
           .traverse(k => Semaphore[IO](1).map(s => k -> s))
           .map(_.toMap)
-        res <- req.splitShard(active, shardSemaphores, 50)
+        shardSemaphoresRef <- Ref
+          .of[IO, Map[ShardSemaphoresKey, Semaphore[IO]]](
+            shardSemaphores
+          )
+        res <- req.splitShard(streamsRef, shardSemaphoresRef, 50)
+        s <- streamsRef.get
       } yield assert(
-        res.isValid && res.exists { case (resultStreams, _) =>
-          resultStreams.streams.get(streamName).exists { stream =>
-            stream.shards.keys.toList.count(shard =>
-              shard.parentShardId.contains(shardToSplit.shardId.shardId)
-            ) == 2 && stream.streamStatus == StreamStatus.UPDATING
-          }
+        res.isValid && s.streams.get(streamName).exists { stream =>
+          stream.shards.keys.toList.count(shard =>
+            shard.parentShardId.contains(shardToSplit.shardId.shardId)
+          ) == 2 && stream.streamStatus == StreamStatus.UPDATING
         },
         s"req: $req\n" +
-          s"resShards: ${res.map(_._1.streams(streamName).shards.keys.map(_.shardId))}"
+          s"resShards: ${s.streams(streamName).shards.keys.map(_.shardId)}"
       )
   })
 
@@ -91,14 +95,16 @@ class SplitShardTests
         )
 
       for {
+        streamsRef <- Ref.of[IO, Streams](streams)
         shardSemaphores <- shardSemaphoreKeys
           .traverse(k => Semaphore[IO](1).map(s => k -> s))
           .map(_.toMap)
-        res <- req.splitShard(streams, shardSemaphores, 50)
-      } yield assert(
-        res.isInvalid,
-        s"req: $req\nres: $res"
-      )
+        shardSemaphoresRef <- Ref
+          .of[IO, Map[ShardSemaphoresKey, Semaphore[IO]]](
+            shardSemaphores
+          )
+        res <- req.splitShard(streamsRef, shardSemaphoresRef, 50)
+      } yield assert(res.isInvalid, s"req: $req\nres: $res")
   })
 
   test("It should reject if the shard is not found")(PropF.forAllF {
@@ -131,14 +137,16 @@ class SplitShardTests
         )
 
       for {
+        streamsRef <- Ref.of[IO, Streams](active)
         shardSemaphores <- shardSemaphoreKeys
           .traverse(k => Semaphore[IO](1).map(s => k -> s))
           .map(_.toMap)
-        res <- req.splitShard(active, shardSemaphores, 50)
-      } yield assert(
-        res.isInvalid,
-        s"req: $req\nres: $res"
-      )
+        shardSemaphoresRef <- Ref
+          .of[IO, Map[ShardSemaphoresKey, Semaphore[IO]]](
+            shardSemaphores
+          )
+        res <- req.splitShard(streamsRef, shardSemaphoresRef, 50)
+      } yield assert(res.isInvalid, s"req: $req\nres: $res")
   })
 
   test("It should reject if the operation would exceed the shard limit")(
@@ -173,14 +181,16 @@ class SplitShardTests
           )
 
         for {
+          streamsRef <- Ref.of[IO, Streams](active)
           shardSemaphores <- shardSemaphoreKeys
             .traverse(k => Semaphore[IO](1).map(s => k -> s))
             .map(_.toMap)
-          res <- req.splitShard(active, shardSemaphores, 5)
-        } yield assert(
-          res.isInvalid,
-          s"req: $req\nres: $res"
-        )
+          shardSemaphoresRef <- Ref
+            .of[IO, Map[ShardSemaphoresKey, Semaphore[IO]]](
+              shardSemaphores
+            )
+          res <- req.splitShard(streamsRef, shardSemaphoresRef, 5)
+        } yield assert(res.isInvalid, s"req: $req\nres: $res")
     }
   )
 }

--- a/src/test/scala/kinesis/mock/api/StopStreamEncryptionTests.scala
+++ b/src/test/scala/kinesis/mock/api/StopStreamEncryptionTests.scala
@@ -1,14 +1,18 @@
 package kinesis.mock.api
 
+import cats.effect.IO
+import cats.effect.concurrent.Ref
 import enumeratum.scalacheck._
-import org.scalacheck.Prop._
+import org.scalacheck.effect.PropF
 
 import kinesis.mock.instances.arbitrary._
 import kinesis.mock.models._
 import kinesis.mock.syntax.scalacheck._
 
-class StopStreamEncryptionTests extends munit.ScalaCheckSuite {
-  property("It should stop stream encryption")(forAll {
+class StopStreamEncryptionTests
+    extends munit.CatsEffectSuite
+    with munit.ScalaCheckEffectSuite {
+  test("It should stop stream encryption")(PropF.forAllF {
     (
         streamName: StreamName,
         awsRegion: AwsRegion,
@@ -23,44 +27,55 @@ class StopStreamEncryptionTests extends munit.ScalaCheckSuite {
 
       val keyId = keyIdGen.one
 
-      val req =
-        StopStreamEncryptionRequest(EncryptionType.KMS, keyId, streamName)
-      val res = req.stopStreamEncryption(asActive)
-
-      (res.isValid && res.exists { s =>
-        s.streams
+      for {
+        streamsRef <- Ref.of[IO, Streams](asActive)
+        req = StopStreamEncryptionRequest(EncryptionType.KMS, keyId, streamName)
+        res <- req.stopStreamEncryption(streamsRef)
+        s <- streamsRef.get
+      } yield assert(
+        res.isValid && s.streams
           .get(streamName)
           .exists { s =>
             s.keyId.isEmpty &&
             s.encryptionType == EncryptionType.NONE &&
             s.streamStatus == StreamStatus.UPDATING
-          }
-      }) :| s"req: $req\nres: $res\nstreams: $asActive"
-  })
-
-  property("It should reject when the KMS encryption type is not used")(forAll {
-    (
-        streamName: StreamName,
-        awsRegion: AwsRegion,
-        awsAccountId: AwsAccountId
-    ) =>
-      val (streams, _) =
-        Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
-
-      val asActive = streams.findAndUpdateStream(streamName)(x =>
-        x.copy(streamStatus = StreamStatus.ACTIVE)
+          },
+        s"req: $req\nres: $res\nstreams: $asActive"
       )
-
-      val keyId = keyIdGen.one
-
-      val req =
-        StopStreamEncryptionRequest(EncryptionType.NONE, keyId, streamName)
-      val res = req.stopStreamEncryption(asActive)
-
-      res.isInvalid :| s"req: $req\nres: $res\nstreams: $streams"
   })
 
-  property("It should reject when the stream is not active")(forAll {
+  test("It should reject when the KMS encryption type is not used")(
+    PropF.forAllF {
+      (
+          streamName: StreamName,
+          awsRegion: AwsRegion,
+          awsAccountId: AwsAccountId
+      ) =>
+        val (streams, _) =
+          Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
+
+        val asActive = streams.findAndUpdateStream(streamName)(x =>
+          x.copy(streamStatus = StreamStatus.ACTIVE)
+        )
+
+        val keyId = keyIdGen.one
+
+        for {
+          streamsRef <- Ref.of[IO, Streams](asActive)
+          req = StopStreamEncryptionRequest(
+            EncryptionType.NONE,
+            keyId,
+            streamName
+          )
+          res <- req.stopStreamEncryption(streamsRef)
+        } yield assert(
+          res.isInvalid,
+          s"req: $req\nres: $res\nstreams: $asActive"
+        )
+    }
+  )
+
+  test("It should reject when the stream is not active")(PropF.forAllF {
     (
         streamName: StreamName,
         awsRegion: AwsRegion,
@@ -71,10 +86,17 @@ class StopStreamEncryptionTests extends munit.ScalaCheckSuite {
 
       val keyId = keyIdGen.one
 
-      val req =
-        StopStreamEncryptionRequest(EncryptionType.KMS, keyId, streamName)
-      val res = req.stopStreamEncryption(streams)
-
-      res.isInvalid :| s"req: $req\nres: $res\nstreams: $streams"
+      for {
+        streamsRef <- Ref.of[IO, Streams](streams)
+        req = StopStreamEncryptionRequest(
+          EncryptionType.KMS,
+          keyId,
+          streamName
+        )
+        res <- req.stopStreamEncryption(streamsRef)
+      } yield assert(
+        res.isInvalid,
+        s"req: $req\nres: $res\nstreams: $streams"
+      )
   })
 }

--- a/src/test/scala/kinesis/mock/api/UpdateShardCountTests.scala
+++ b/src/test/scala/kinesis/mock/api/UpdateShardCountTests.scala
@@ -2,7 +2,7 @@ package kinesis.mock
 package api
 
 import cats.effect._
-import cats.effect.concurrent.Semaphore
+import cats.effect.concurrent.{Ref, Semaphore}
 import cats.syntax.all._
 import enumeratum.scalacheck._
 import org.scalacheck.effect.PropF
@@ -34,31 +34,31 @@ class UpdateShardCountTests
         )
 
       for {
+        streamsRef <- Ref.of[IO, Streams](active)
         shardSemaphores <- shardSemaphoreKeys
           .traverse(k => Semaphore[IO](1).map(s => k -> s))
           .map(_.toMap)
-        res <- req.updateShardCount(active, shardSemaphores, 50)
+        shardSemaphoresRef <- Ref
+          .of[IO, Map[ShardSemaphoresKey, Semaphore[IO]]](
+            shardSemaphores
+          )
+        res <- req.updateShardCount(streamsRef, shardSemaphoresRef, 50)
+        s <- streamsRef.get
       } yield assert(
-        res.isValid && res.exists { case (resultStreams, _) =>
-          resultStreams.streams.get(streamName).exists { stream =>
-            val shards = stream.shards.keys.toList
-            shards.count(_.isOpen) == 10 &&
-            shards.filterNot(_.isOpen).map(_.shardId) == active
-              .streams(streamName)
-              .shards
-              .keys
-              .toList
-              .map(_.shardId) &&
-            stream.streamStatus == StreamStatus.UPDATING
-          }
+        res.isValid && s.streams.get(streamName).exists { stream =>
+          val shards = stream.shards.keys.toList
+          shards.count(_.isOpen) == 10 &&
+          shards.filterNot(_.isOpen).map(_.shardId) == active
+            .streams(streamName)
+            .shards
+            .keys
+            .toList
+            .map(_.shardId) &&
+          stream.streamStatus == StreamStatus.UPDATING
         },
         s"req: $req\n" +
-          s"resOpenShards: ${res.map { case (resultStreams, _) =>
-            resultStreams.streams(streamName).shards.keys.toList.filter(_.isOpen).map(_.shardId)
-          }}\n" +
-          s"resClosedShards: ${res.map { case (resultStreams, _) =>
-            resultStreams.streams(streamName).shards.keys.toList.filterNot(_.isOpen).map(_.shardId)
-          }}\n" +
+          s"resOpenShards: ${s.streams(streamName).shards.keys.toList.filter(_.isOpen).map(_.shardId)}\n" +
+          s"resClosedShards: ${s.streams(streamName).shards.keys.toList.filterNot(_.isOpen).map(_.shardId)}\n" +
           s"inputShards: ${active.streams(streamName).shards.keys.toList.map(_.shardId)}"
       )
   })
@@ -84,31 +84,31 @@ class UpdateShardCountTests
         )
 
       for {
+        streamsRef <- Ref.of[IO, Streams](active)
         shardSemaphores <- shardSemaphoreKeys
           .traverse(k => Semaphore[IO](1).map(s => k -> s))
           .map(_.toMap)
-        res <- req.updateShardCount(active, shardSemaphores, 50)
+        shardSemaphoresRef <- Ref
+          .of[IO, Map[ShardSemaphoresKey, Semaphore[IO]]](
+            shardSemaphores
+          )
+        res <- req.updateShardCount(streamsRef, shardSemaphoresRef, 50)
+        s <- streamsRef.get
       } yield assert(
-        res.isValid && res.exists { case (resultStreams, _) =>
-          resultStreams.streams.get(streamName).exists { stream =>
-            val shards = stream.shards.keys.toList
-            shards.count(_.isOpen) == 5 &&
-            shards.filterNot(_.isOpen).map(_.shardId) == active
-              .streams(streamName)
-              .shards
-              .keys
-              .toList
-              .map(_.shardId) &&
-            stream.streamStatus == StreamStatus.UPDATING
-          }
+        res.isValid && s.streams.get(streamName).exists { stream =>
+          val shards = stream.shards.keys.toList
+          shards.count(_.isOpen) == 5 &&
+          shards.filterNot(_.isOpen).map(_.shardId) == active
+            .streams(streamName)
+            .shards
+            .keys
+            .toList
+            .map(_.shardId) &&
+          stream.streamStatus == StreamStatus.UPDATING
         },
         s"req: $req\n" +
-          s"resOpenShards: ${res.map { case (resultStreams, _) =>
-            resultStreams.streams(streamName).shards.keys.toList.filter(_.isOpen).map(_.shardId)
-          }}\n" +
-          s"resClosedShards: ${res.map { case (resultStreams, _) =>
-            resultStreams.streams(streamName).shards.keys.toList.filterNot(_.isOpen).map(_.shardId)
-          }}\n" +
+          s"resOpenShards: ${s.streams(streamName).shards.keys.toList.filter(_.isOpen).map(_.shardId)}\n" +
+          s"resClosedShards: ${s.streams(streamName).shards.keys.toList.filterNot(_.isOpen).map(_.shardId)}\n" +
           s"inputShards: ${active.streams(streamName).shards.keys.toList.map(_.shardId)}"
       )
   })
@@ -135,14 +135,16 @@ class UpdateShardCountTests
           )
 
         for {
+          streamsRef <- Ref.of[IO, Streams](active)
           shardSemaphores <- shardSemaphoreKeys
             .traverse(k => Semaphore[IO](1).map(s => k -> s))
             .map(_.toMap)
-          res <- req.updateShardCount(active, shardSemaphores, 50)
-        } yield assert(
-          res.isInvalid,
-          s"req: $req\nres: $res"
-        )
+          shardSemaphoresRef <- Ref
+            .of[IO, Map[ShardSemaphoresKey, Semaphore[IO]]](
+              shardSemaphores
+            )
+          res <- req.updateShardCount(streamsRef, shardSemaphoresRef, 50)
+        } yield assert(res.isInvalid, s"req: $req\nres: $res")
     }
   )
 
@@ -168,14 +170,16 @@ class UpdateShardCountTests
           )
 
         for {
+          streamsRef <- Ref.of[IO, Streams](active)
           shardSemaphores <- shardSemaphoreKeys
             .traverse(k => Semaphore[IO](1).map(s => k -> s))
             .map(_.toMap)
-          res <- req.updateShardCount(active, shardSemaphores, 50)
-        } yield assert(
-          res.isInvalid,
-          s"req: $req\nres: $res"
-        )
+          shardSemaphoresRef <- Ref
+            .of[IO, Map[ShardSemaphoresKey, Semaphore[IO]]](
+              shardSemaphores
+            )
+          res <- req.updateShardCount(streamsRef, shardSemaphoresRef, 50)
+        } yield assert(res.isInvalid, s"req: $req\nres: $res")
     }
   )
 
@@ -200,14 +204,16 @@ class UpdateShardCountTests
         )
 
       for {
+        streamsRef <- Ref.of[IO, Streams](active)
         shardSemaphores <- shardSemaphoreKeys
           .traverse(k => Semaphore[IO](1).map(s => k -> s))
           .map(_.toMap)
-        res <- req.updateShardCount(active, shardSemaphores, 9)
-      } yield assert(
-        res.isInvalid,
-        s"req: $req\nres: $res"
-      )
+        shardSemaphoresRef <- Ref
+          .of[IO, Map[ShardSemaphoresKey, Semaphore[IO]]](
+            shardSemaphores
+          )
+        res <- req.updateShardCount(streamsRef, shardSemaphoresRef, 9)
+      } yield assert(res.isInvalid, s"req: $req\nres: $res")
   })
 
   test("It should reject if the stream is not active")(PropF.forAllF {
@@ -227,13 +233,15 @@ class UpdateShardCountTests
         )
 
       for {
+        streamsRef <- Ref.of[IO, Streams](streams)
         shardSemaphores <- shardSemaphoreKeys
           .traverse(k => Semaphore[IO](1).map(s => k -> s))
           .map(_.toMap)
-        res <- req.updateShardCount(streams, shardSemaphores, 50)
-      } yield assert(
-        res.isInvalid,
-        s"req: $req\nres: $res"
-      )
+        shardSemaphoresRef <- Ref
+          .of[IO, Map[ShardSemaphoresKey, Semaphore[IO]]](
+            shardSemaphores
+          )
+        res <- req.updateShardCount(streamsRef, shardSemaphoresRef, 50)
+      } yield assert(res.isInvalid, s"req: $req\nres: $res")
   })
 }


### PR DESCRIPTION
## Changes Introduced

Refactor to fix race conditions. Replaces `set` calls with `update`. All API calls now take a `Ref` rather than the `Streams` object directly.

## Applicable linked issues

#33 

## Checklist (check all that apply)

- [x] This change maintains backwards compatibility
- [ ] I have introduced tests for all new features and changes
- [ ] I have added documentation covering all new features and changes
- [x] This pull-request is ready for review