### PR TITLE
Remove Custom Resolver for Scalacheck-Gen-Regexp

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,6 @@ lazy val kinesisMock = project
     organization := "io.github.etspaceman",
     description := "A Mock API for AWS Kinesis",
     scalaVersion := "2.13.5",
-    resolvers += Resolver.bintrayRepo("wolfendale", "maven"),
     libraryDependencies ++= Seq(
       Aws.utils,
       Borer.circe,

--- a/project/LibraryDependencies.scala
+++ b/project/LibraryDependencies.scala
@@ -7,7 +7,7 @@ object LibraryDependencies {
   val Logback = "ch.qos.logback" % "logback-classic" % "1.2.3"
   val BetterMonadicFor = "com.olegpy" %% "better-monadic-for" % "0.3.1"
   val JaxbApi = "javax.xml.bind" % "jaxb-api" % "2.3.1"
-  val ScalacheckGenRegexp = "wolfendale" %% "scalacheck-gen-regexp" % "0.1.3"
+  val ScalacheckGenRegexp = "io.github.wolfendale" %% "scalacheck-gen-regexp" % "0.1.3"
   val UUIDCreator = "com.github.f4b6a3" % "uuid-creator" % "3.7.0"
   val GraalSvm = "org.graalvm.nativeimage" % "svm" % "21.1.0"
   val CatsRetry = "com.github.cb372" %% "cats-retry" % "2.1.0"

--- a/project/LibraryDependencies.scala
+++ b/project/LibraryDependencies.scala
@@ -7,7 +7,7 @@ object LibraryDependencies {
   val Logback = "ch.qos.logback" % "logback-classic" % "1.2.3"
   val BetterMonadicFor = "com.olegpy" %% "better-monadic-for" % "0.3.1"
   val JaxbApi = "javax.xml.bind" % "jaxb-api" % "2.3.1"
-  val ScalacheckGenRegexp = "wolfendale" %% "scalacheck-gen-regexp" % "0.1.2"
+  val ScalacheckGenRegexp = "wolfendale" %% "scalacheck-gen-regexp" % "0.1.3"
   val UUIDCreator = "com.github.f4b6a3" % "uuid-creator" % "3.7.0"
   val GraalSvm = "org.graalvm.nativeimage" % "svm" % "21.1.0"
   val CatsRetry = "com.github.cb372" %% "cats-retry" % "2.1.0"

--- a/project/LibraryDependencies.scala
+++ b/project/LibraryDependencies.scala
@@ -7,7 +7,8 @@ object LibraryDependencies {
   val Logback = "ch.qos.logback" % "logback-classic" % "1.2.3"
   val BetterMonadicFor = "com.olegpy" %% "better-monadic-for" % "0.3.1"
   val JaxbApi = "javax.xml.bind" % "jaxb-api" % "2.3.1"
-  val ScalacheckGenRegexp = "io.github.wolfendale" %% "scalacheck-gen-regexp" % "0.1.3"
+  val ScalacheckGenRegexp =
+    "io.github.wolfendale" %% "scalacheck-gen-regexp" % "0.1.3"
   val UUIDCreator = "com.github.f4b6a3" % "uuid-creator" % "3.7.0"
   val GraalSvm = "org.graalvm.nativeimage" % "svm" % "21.1.0"
   val CatsRetry = "com.github.cb372" %% "cats-retry" % "2.1.0"


### PR DESCRIPTION
## Changes Introduced

Removing the custom resolver for scalacheck-gen-regexp per https://github.com/wolfendale/scalacheck-gen-regexp/issues/8

## Applicable linked issues

N/A

## Checklist (check all that apply)

- [ ] This change maintains backwards compatibility
- [ ] I have introduced tests for all new features and changes
- [ ] I have added documentation covering all new features and changes
- [ ] This pull-request is ready for review