### PR TITLE
Downgrade Http4s due to AWS CLI issues

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,3 @@
+updates.pin  = [
+    { groupId = "org.http4s", version = "0.21.22" }
+]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.2'
+version: '2.4'
 services:
   dynamodb:
     command: "-jar DynamoDBLocal.jar -inMemory"
@@ -32,6 +32,17 @@ services:
     ports:
       - "4567:4567"
       - "4568:4568"
+  awscli:
+    image: amazon/aws-cli:latest
+    environment:
+      - "AWS_ACCESS_KEY_ID=foo"
+      - "AWS_SECRET_ACCESS_KEY=bar"
+      - "AWS_DEFAULT_REGION=us-east-1"
+    entrypoint: "bash -c"
+    command: "'aws --endpoint-url 'https://kinesis-mock:4567/' --no-verify-ssl kinesis list-streams && exit 0 || exit 1'"
+    depends_on:
+      kinesis-mock:
+        condition: service_healthy
   ready:
     image: "library/hello-world"
     depends_on:
@@ -39,6 +50,8 @@ services:
         condition: service_healthy
       kinesis-mock:
         condition: service_healthy
+      awscli:
+        condition: service_completed_successfully
 networks:
   default:
     external:

--- a/project/LibraryDependencies.scala
+++ b/project/LibraryDependencies.scala
@@ -49,7 +49,7 @@ object LibraryDependencies {
   }
 
   object Http4s {
-    val http4sVersion = "0.21.24"
+    val http4sVersion = "0.21.22"
     val blazeServer = "org.http4s" %% "http4s-blaze-server" % http4sVersion
     val circe = "org.http4s" %% "http4s-circe" % http4sVersion
     val dsl = "org.http4s" %% "http4s-dsl" % http4sVersion


### PR DESCRIPTION
## Changes Introduced

The newest Http4s version broke AWS CLI interactions. The SDK and Curl work just fine, but for some reason the AWS CLI was not working.

This downgrades Http4s and adds a test for the AWS CLI interaction

## Applicable linked issues

## Checklist (check all that apply)

- [x] This change maintains backwards compatibility
- [x] I have introduced tests for all new features and changes
- [ ] I have added documentation covering all new features and changes
- [x] This pull-request is ready for review