### PR TITLE
Add docker-compose ps -a to failure logs in CI

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -24,6 +24,9 @@ jobs:
       env:
         CBOR_ENABLED: ${{ matrix.cbor_enabled }}
         SERVICE_PORT: ${{ matrix.service_port }}
+    - name: Print Docker Container Listing
+      if: ${{ failure() }}
+      run: sbt dockerComposePs
     - name: Print Docker Logs
       if: ${{ failure() }}
       run: sbt dockerComposeLogs


### PR DESCRIPTION
## Changes Introduced

Adds docker-compose ps -a to the failure logs in the CI

## Applicable linked issues

None

## Checklist (check all that apply)

- [x] This change maintains backwards compatibility
- [ ] I have introduced tests for all new features and changes
- [ ] I have added documentation covering all new features and changes
- [x] This pull-request is ready for review