### PR TITLE
Fix GetShardIterator - given a sequence number for the start of a shard

### DIFF
--- a/src/main/scala/kinesis/mock/api/GetShardIteratorRequest.scala
+++ b/src/main/scala/kinesis/mock/api/GetShardIteratorRequest.scala
@@ -127,6 +127,20 @@ final case class GetShardIteratorRequest(
                               ShardIteratorType.AT_SEQUENCE_NUMBER,
                               Some(seqNo),
                               _
+                            ) if seqNo == shard.sequenceNumberRange.startingSequenceNumber =>
+                          Valid(
+                            GetShardIteratorResponse(
+                              ShardIterator.create(
+                                streamName,
+                                shardId,
+                                shard.sequenceNumberRange.startingSequenceNumber
+                              )
+                            )
+                          )
+                        case (
+                              ShardIteratorType.AT_SEQUENCE_NUMBER,
+                              Some(seqNo),
+                              _
                             ) =>
                           data.find(_.sequenceNumber == seqNo) match {
                             case Some(record) =>
@@ -152,23 +166,25 @@ final case class GetShardIteratorRequest(
                                     )
                                   )
                                 )
-                            case None
-                                if seqNo == shard.sequenceNumberRange.startingSequenceNumber =>
-                              Valid(
-                                GetShardIteratorResponse(
-                                  ShardIterator.create(
-                                    streamName,
-                                    shardId,
-                                    shard.sequenceNumberRange.startingSequenceNumber
-                                  )
-                                )
-                              )
                             case None =>
                               ResourceNotFoundException(
                                 s"Unable to find record with provided SequenceNumber $seqNo in stream $streamName"
                               ).invalidNel
                           }
-
+                        case (
+                              ShardIteratorType.AFTER_SEQUENCE_NUMBER,
+                              Some(seqNo),
+                              _
+                            ) if seqNo == shard.sequenceNumberRange.startingSequenceNumber =>
+                          Valid(
+                            GetShardIteratorResponse(
+                              ShardIterator.create(
+                                streamName,
+                                shardId,
+                                shard.sequenceNumberRange.startingSequenceNumber
+                              )
+                            )
+                          )
                         case (
                               ShardIteratorType.AFTER_SEQUENCE_NUMBER,
                               Some(seqNo),
@@ -182,17 +198,6 @@ final case class GetShardIteratorRequest(
                                     streamName,
                                     shardId,
                                     data(data.indexOf(record)).sequenceNumber
-                                  )
-                                )
-                              )
-                            case None
-                                if seqNo == shard.sequenceNumberRange.startingSequenceNumber =>
-                              Valid(
-                                GetShardIteratorResponse(
-                                  ShardIterator.create(
-                                    streamName,
-                                    shardId,
-                                    shard.sequenceNumberRange.startingSequenceNumber
                                   )
                                 )
                               )

--- a/src/main/scala/kinesis/mock/api/GetShardIteratorRequest.scala
+++ b/src/main/scala/kinesis/mock/api/GetShardIteratorRequest.scala
@@ -152,6 +152,17 @@ final case class GetShardIteratorRequest(
                                     )
                                   )
                                 )
+                            case None
+                                if seqNo == shard.sequenceNumberRange.startingSequenceNumber =>
+                              Valid(
+                                GetShardIteratorResponse(
+                                  ShardIterator.create(
+                                    streamName,
+                                    shardId,
+                                    shard.sequenceNumberRange.startingSequenceNumber
+                                  )
+                                )
+                              )
                             case None =>
                               ResourceNotFoundException(
                                 s"Unable to find record with provided SequenceNumber $seqNo in stream $streamName"
@@ -171,6 +182,17 @@ final case class GetShardIteratorRequest(
                                     streamName,
                                     shardId,
                                     data(data.indexOf(record)).sequenceNumber
+                                  )
+                                )
+                              )
+                            case None
+                                if seqNo == shard.sequenceNumberRange.startingSequenceNumber =>
+                              Valid(
+                                GetShardIteratorResponse(
+                                  ShardIterator.create(
+                                    streamName,
+                                    shardId,
+                                    shard.sequenceNumberRange.startingSequenceNumber
                                   )
                                 )
                               )


### PR DESCRIPTION
## Changes Introduced

If GetShardIterator is called with AT_SEQUENCE_NUMBER or AFTER_SEQUENCE_NUMBER, and the startingSequenceNumber of a shard is provided, the mock will currently error out if no record has been produced with this. This is not the correct behavior. This PR allows for these values to be submitted with the request.

## Applicable linked issues

https://github.com/localstack/localstack/issues/4137

## Checklist (check all that apply)

- [X] This change maintains backwards compatibility
- [X] I have introduced tests for all new features and changes
- [ ] I have added documentation covering all new features and changes
- [X] This pull-request is ready for review