### PR TITLE
Publish Native Image Release Assets for Linux, MacOS and Windows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,109 @@ on:
     types: [published]
 
 jobs:
-  build:
+  buildWindowsExecutable:
+    name: Build Native Image Exceutable for Windows
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ilammy/msvc-dev-cmd@v1.5.0
+    - uses: microsoft/setup-msbuild@v1
+    - uses: ayltai/setup-graalvm@v1
+      with:
+        java-version: 11
+        graalvm-version: 21.0.0.2
+        native-image: true
+    - name: Build assembly jar
+      run: sbt assembly
+      shell: powershell
+    - name: Build native image
+      run: graal/buildNativeImage.sh
+      env:
+        JAR_FILE: docker/image/lib/kinesis-mock.jar
+        OUTPUT_FILE: kinesis-mock.exe
+    - name: Run UPX
+      uses: crazy-max/ghaction-upx@v1.3.3
+      with:
+        version: latest
+        file: kinesis-mock.exe
+        args: '-7'
+    - name: Upload to release
+      id: upload-release-asset 
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./kinesis-mock.exe
+        asset_name: kinesis-mock.exe
+        asset_content_type: application/vnd.microsoft.portable-executable
+  buildLinuxExecutable:
+    name: Build Native Image Exceutable for Linux
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ayltai/setup-graalvm@v1
+      with:
+        java-version: 11
+        graalvm-version: 21.0.0.2
+        native-image: true
+    - name: Build assembly jar
+      run: sbt assembly
+    - name: Build native image
+      run: graal/buildNativeImage.sh
+      env:
+        JAR_FILE: docker/image/lib/kinesis-mock.jar
+        OUTPUT_FILE: kinesis-mock-linux-amd64
+    - name: Run UPX
+      uses: crazy-max/ghaction-upx@v1.3.3
+      with:
+        version: latest
+        file: kinesis-mock-linux-amd64
+        args: '-7'
+    - name: Upload to release
+      id: upload-release-asset 
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./kinesis-mock-linux-amd64
+        asset_name: kinesis-mock-linux-amd64
+        asset_content_type: application/octet-stream
+  buildMacOSExecutable:
+    name: Build Native Image Exceutable for MacOS
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ayltai/setup-graalvm@v1
+      with:
+        java-version: 11
+        graalvm-version: 21.0.0.2
+        native-image: true
+    - name: Build assembly jar
+      run: sbt assembly
+    - name: Build native image
+      run: graal/buildNativeImage.sh
+      env:
+        JAR_FILE: docker/image/lib/kinesis-mock.jar
+        OUTPUT_FILE: kinesis-mock-macos-amd64
+    - name: Run UPX
+      uses: crazy-max/ghaction-upx@v1.3.3
+      with:
+        version: latest
+        file: kinesis-mock-macos-amd64
+        args: '-7'
+    - name: Upload to release
+      id: upload-release-asset 
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./kinesis-mock-macos-amd64
+        asset_name: kinesis-mock-macos-amd64
+        asset_content_type: application/octet-stream
+  buildDockerImage:
     name: Push Docker image to Container Registry
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,10 +21,11 @@ jobs:
       run: sbt assembly
       shell: powershell
     - name: Build native image
-      run: graal/buildNativeImage.sh
+      run: graal\buildNativeImage.ps
       env:
-        JAR_FILE: docker/image/lib/kinesis-mock.jar
+        JAR_FILE: docker\image\lib\kinesis-mock.jar
         OUTPUT_FILE: kinesis-mock.exe
+      shell: powershell
     - name: Run UPX
       uses: crazy-max/ghaction-upx@v1.3.3
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,9 +21,9 @@ jobs:
       run: sbt assembly
       shell: powershell
     - name: Build native image
-      run: graal\buildNativeImage.ps
+      run: graal/buildNativeImage.ps
       env:
-        JAR_FILE: docker\image\lib\kinesis-mock.jar
+        JAR_FILE: docker/image/lib/kinesis-mock.jar
         OUTPUT_FILE: kinesis-mock.exe
       shell: powershell
     - name: Run UPX
@@ -42,6 +42,7 @@ jobs:
         asset_path: ./kinesis-mock.exe
         asset_name: kinesis-mock.exe
         asset_content_type: application/vnd.microsoft.portable-executable
+
   buildLinuxExecutable:
     name: Build Native Image Exceutable for Linux
     runs-on: ubuntu-latest
@@ -75,6 +76,7 @@ jobs:
         asset_path: ./kinesis-mock-linux-amd64
         asset_name: kinesis-mock-linux-amd64
         asset_content_type: application/octet-stream
+
   buildMacOSExecutable:
     name: Build Native Image Exceutable for MacOS
     runs-on: macos-latest
@@ -108,6 +110,7 @@ jobs:
         asset_path: ./kinesis-mock-macos-amd64
         asset_name: kinesis-mock-macos-amd64
         asset_content_type: application/octet-stream
+        
   buildDockerImage:
     name: Push Docker image to Container Registry
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -28,10 +28,22 @@ docker pull ghcr.io/etspaceman/kinesis-mock:0.0.8
 docker run -p 4567:4567 -p 4568:4568 ghcr.io/etspaceman/kinesis-mock:0.0.8
 ```
 
-You can also leverage the `kinesis-mock.jar` executable in the release assets:
+You can also leverage the following executable options in the release assets:
 
 ```shell
 java -jar ./kinesis-mock.jar
+```
+
+```shell
+kinesis-mock-linux-amd64
+```
+
+```shell
+kinesis-mock-macos-amd64
+```
+
+```powershell
+kinesis-mock.exe
 ```
 
 # Service Configuration

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,6 @@
 FROM ghcr.io/graalvm/graalvm-ce:java11-21.0.0.2 as build
 RUN gu install native-image
 
-# BEGIN PRE-REQUISITES FOR STATIC NATIVE IMAGES FOR GRAAL 20.2.0
-# SEE: https://github.com/oracle/graal/blob/master/substratevm/StaticImages.md
 ARG RESULT_LIB="/staticlibs"
 
 RUN mkdir ${RESULT_LIB} && \
@@ -21,30 +19,12 @@ RUN curl -L -o zlib.tar.gz https://zlib.net/zlib-1.2.11.tar.gz && \
    ./configure --static --prefix=${RESULT_LIB} && \
     make && make install && \
     cd / && rm -rf /zlib && rm -f /zlib.tar.gz
-#END PRE-REQUISITES FOR STATIC NATIVE IMAGES FOR GRAAL 20.2.0
+
 ARG DOCKER_SERVICE_JAR
 COPY ${DOCKER_SERVICE_JAR} ./kinesis-mock.jar
 COPY graal ./graal
 
-RUN native-image \
-    --no-server \
-    --static \
-    --libc=musl \
-    -J-Xmx7G \
-    --no-fallback \
-    --verbose \
-    --enable-all-security-services \
-    --enable-url-protocols=http,https \
-    --initialize-at-build-time=scala \
-    -H:ReflectionConfigurationFiles=graal/reflect-config.json \
-    -H:ResourceConfigurationFiles=graal/resource-config.json \
-    -H:+ReportExceptionStackTraces \
-    -H:+AddAllCharsets \
-    --report-unsupported-elements-at-runtime \
-    --allow-incomplete-classpath \
-    --install-exit-handlers \
-    -jar kinesis-mock.jar \
-    kinesis-mock-native
+RUN ./graal/buildNativeImage.sh
 
 RUN microdnf install xz && \
     curl -sL -o - https://github.com/upx/upx/releases/download/v3.96/upx-3.96-amd64_linux.tar.xz | tar xJ && \

--- a/graal/buildNativeImage.ps1
+++ b/graal/buildNativeImage.ps1
@@ -1,0 +1,22 @@
+$JAR_FILE = $env:JAR_FILE ?? "kinesis-mock.jar";
+$OUTPUT_FILE = $env:OUTPUT_FILE ?? "kinesis-mock-native";
+
+native-image.cmd `
+    --no-server `
+    --static `
+    --libc=musl `
+    -J-Xmx7G `
+    --no-fallback `
+    --verbose `
+    --enable-all-security-services `
+    --enable-url-protocols=http,https `
+    --initialize-at-build-time=scala `
+    -H:ReflectionConfigurationFiles=graal\reflect-config.json `
+    -H:ResourceConfigurationFiles=graal\resource-config.json `
+    -H:+ReportExceptionStackTraces `
+    -H:+AddAllCharsets `
+    --report-unsupported-elements-at-runtime `
+    --allow-incomplete-classpath `
+    --install-exit-handlers `
+    -jar $JAR_FILE `
+    $OUTPUT_FILE

--- a/graal/buildNativeImage.ps1
+++ b/graal/buildNativeImage.ps1
@@ -11,8 +11,8 @@ native-image.cmd `
     --enable-all-security-services `
     --enable-url-protocols=http,https `
     --initialize-at-build-time=scala `
-    -H:ReflectionConfigurationFiles=graal\reflect-config.json `
-    -H:ResourceConfigurationFiles=graal\resource-config.json `
+    -H:ReflectionConfigurationFiles=graal/reflect-config.json `
+    -H:ResourceConfigurationFiles=graal/resource-config.json `
     -H:+ReportExceptionStackTraces `
     -H:+AddAllCharsets `
     --report-unsupported-elements-at-runtime `

--- a/graal/buildNativeImage.sh
+++ b/graal/buildNativeImage.sh
@@ -1,0 +1,22 @@
+JAR_FILE=${JAR_FILE:-kinesis-mock.jar}
+OUTPUT_FILE=${OUTPUT_FILE:-kinesis-mock-native}
+
+native-image \
+    --no-server \
+    --static \
+    --libc=musl \
+    -J-Xmx7G \
+    --no-fallback \
+    --verbose \
+    --enable-all-security-services \
+    --enable-url-protocols=http,https \
+    --initialize-at-build-time=scala \
+    -H:ReflectionConfigurationFiles=graal/reflect-config.json \
+    -H:ResourceConfigurationFiles=graal/resource-config.json \
+    -H:+ReportExceptionStackTraces \
+    -H:+AddAllCharsets \
+    --report-unsupported-elements-at-runtime \
+    --allow-incomplete-classpath \
+    --install-exit-handlers \
+    -jar ${JAR_FILE} \
+    ${OUTPUT_FILE}


### PR DESCRIPTION
## Changes Introduced

Adding release-assets for the native-image executables for MacOS, Linux and Windows.

## Applicable linked issues

#11 
https://github.com/localstack/localstack/issues/4137

## Checklist (check all that apply)

- [x] This change maintains backwards compatibility
- [ ] I have introduced tests for all new features and changes
- [x] I have added documentation covering all new features and changes
- [x] This pull-request is ready for review