### PR TITLE
Provide more executables on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,10 +3,15 @@ name: Publish Artifacts and Docker Image
 on:
   release:
     types: [published]
+  pull_request:
+    branches: [ main ]
 
 jobs:
   buildWindowsExecutable:
-    name: Build Native Image Exceutable for Windows
+    name: Build Native Image Exceutables for Windows
+    strategy:
+      matrix:
+        static_type: ["mostly-static", "dynamic"]
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2
@@ -27,6 +32,7 @@ jobs:
       env:
         JAR_FILE: docker\image\lib\kinesis-mock.jar
         OUTPUT_FILE: kinesis-mock
+        STATIC_TYPE: ${{ matrix.static_type }}
       shell: powershell
     - name: Run UPX
       uses: svenstaro/upx-action@v2
@@ -34,19 +40,22 @@ jobs:
         file: ./kinesis-mock.exe
         args: '--best'
         strip: false
-    - name: Upload to release
-      id: upload-release-asset 
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ./kinesis-mock.exe
-        asset_name: kinesis-mock.exe
-        asset_content_type: application/vnd.microsoft.portable-executable
+#    - name: Upload to release
+#      id: upload-release-asset 
+#      uses: actions/upload-release-asset@v1
+#      env:
+#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#      with:
+#        upload_url: ${{ github.event.release.upload_url }}
+#        asset_path: ./kinesis-mock.exe
+#        asset_name: kinesis-mock-${{ matrix.static_type }}.exe
+#        asset_content_type: application/vnd.microsoft.portable-executable
 
   buildLinuxExecutable:
-    name: Build Native Image Exceutable for Linux
+    name: Build Native Image Exceutables for Linux
+    strategy:
+      matrix:
+        static_type: ["static", "mostly-static", "dynamic"]
     runs-on: ubuntu-latest
     steps:
     - name: Check out the repo
@@ -57,21 +66,23 @@ jobs:
         java-version: 1.11
     - name: Build docker image
       run: sbt packageAndBuildDockerImage
+      env:
+        STATIC_TYPE: ${{ matrix.static_type }}
     - name: Run container
       run: graal/buildLinuxImage.sh
-    - name: Upload to release
-      id: upload-release-asset 
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ./shared/kinesis-mock
-        asset_name: kinesis-mock-linux-amd64
-        asset_content_type: application/octet-stream
+#    - name: Upload to release
+#      id: upload-release-asset 
+#      uses: actions/upload-release-asset@v1
+#      env:
+#       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#      with:
+#        upload_url: ${{ github.event.release.upload_url }}
+#        asset_path: ./shared/kinesis-mock
+#        asset_name: kinesis-mock-linux-amd64-${{ matrix.static_type }}
+#        asset_content_type: application/octet-stream
 
   buildMacOSExecutable:
-    name: Build Native Image Exceutable for MacOS
+    name: Build Native Image Exceutables for MacOS
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
@@ -95,16 +106,16 @@ jobs:
         file: ./kinesis-mock-macos-amd64
         args: '--best'
         strip: false
-    - name: Upload to release
-      id: upload-release-asset 
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ./kinesis-mock-macos-amd64
-        asset_name: kinesis-mock-macos-amd64
-        asset_content_type: application/octet-stream
+#    - name: Upload to release
+#      id: upload-release-asset 
+#      uses: actions/upload-release-asset@v1
+#      env:
+#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#      with:
+#        upload_url: ${{ github.event.release.upload_url }}
+#        asset_path: ./kinesis-mock-macos-amd64
+#        asset_name: kinesis-mock-macos-amd64-dynamic
+#        asset_content_type: application/octet-stream
         
   buildDockerImage:
     name: Push Docker image to Container Registry
@@ -120,15 +131,15 @@ jobs:
       run: sbt packageAndBuildDockerImage
     - name: Login to registry
       run: echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
-    - name: Push to registry
-      run: docker push ghcr.io/etspaceman/kinesis-mock:${{ github.event.release.tag_name }}
-    - name: Upload JAR To Release
-      id: upload-release-asset 
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ./docker/image/lib/kinesis-mock.jar
-        asset_name: kinesis-mock.jar
-        asset_content_type: application/java-archive
+#    - name: Push to registry
+#      run: docker push ghcr.io/etspaceman/kinesis-mock:${{ github.event.release.tag_name }}
+#    - name: Upload JAR To Release
+#      id: upload-release-asset 
+#      uses: actions/upload-release-asset@v1
+#      env:
+#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#      with:
+#        upload_url: ${{ github.event.release.upload_url }}
+#        asset_path: ./docker/image/lib/kinesis-mock.jar
+#        asset_name: kinesis-mock.jar
+#        asset_content_type: application/java-archive

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,8 +3,6 @@ name: Publish Artifacts and Docker Image
 on:
   release:
     types: [published]
-  pull_request:
-    branches: [ main ]
 
 jobs:
   buildWindowsExecutable:
@@ -40,16 +38,16 @@ jobs:
         file: ./kinesis-mock.exe
         args: '--best'
         strip: false
-#    - name: Upload to release
-#      id: upload-release-asset 
-#      uses: actions/upload-release-asset@v1
-#      env:
-#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#      with:
-#        upload_url: ${{ github.event.release.upload_url }}
-#        asset_path: ./kinesis-mock.exe
-#        asset_name: kinesis-mock-${{ matrix.static_type }}.exe
-#        asset_content_type: application/vnd.microsoft.portable-executable
+    - name: Upload to release
+      id: upload-release-asset 
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./kinesis-mock.exe
+        asset_name: kinesis-mock-${{ matrix.static_type }}.exe
+        asset_content_type: application/vnd.microsoft.portable-executable
 
   buildLinuxExecutable:
     name: Build Native Image Exceutables for Linux
@@ -70,16 +68,16 @@ jobs:
         STATIC_TYPE: ${{ matrix.static_type }}
     - name: Run container
       run: graal/buildLinuxImage.sh
-#    - name: Upload to release
-#      id: upload-release-asset 
-#      uses: actions/upload-release-asset@v1
-#      env:
-#       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#      with:
-#        upload_url: ${{ github.event.release.upload_url }}
-#        asset_path: ./shared/kinesis-mock
-#        asset_name: kinesis-mock-linux-amd64-${{ matrix.static_type }}
-#        asset_content_type: application/octet-stream
+    - name: Upload to release
+      id: upload-release-asset 
+      uses: actions/upload-release-asset@v1
+      env:
+       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./shared/kinesis-mock
+        asset_name: kinesis-mock-linux-amd64-${{ matrix.static_type }}
+        asset_content_type: application/octet-stream
 
   buildMacOSExecutable:
     name: Build Native Image Exceutables for MacOS
@@ -106,16 +104,16 @@ jobs:
         file: ./kinesis-mock-macos-amd64
         args: '--best'
         strip: false
-#    - name: Upload to release
-#      id: upload-release-asset 
-#      uses: actions/upload-release-asset@v1
-#      env:
-#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#      with:
-#        upload_url: ${{ github.event.release.upload_url }}
-#        asset_path: ./kinesis-mock-macos-amd64
-#        asset_name: kinesis-mock-macos-amd64-dynamic
-#        asset_content_type: application/octet-stream
+    - name: Upload to release
+      id: upload-release-asset 
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./kinesis-mock-macos-amd64
+        asset_name: kinesis-mock-macos-amd64-dynamic
+        asset_content_type: application/octet-stream
         
   buildDockerImage:
     name: Push Docker image to Container Registry
@@ -131,15 +129,15 @@ jobs:
       run: sbt packageAndBuildDockerImage
     - name: Login to registry
       run: echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
-#    - name: Push to registry
-#      run: docker push ghcr.io/etspaceman/kinesis-mock:${{ github.event.release.tag_name }}
-#    - name: Upload JAR To Release
-#      id: upload-release-asset 
-#      uses: actions/upload-release-asset@v1
-#      env:
-#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#      with:
-#        upload_url: ${{ github.event.release.upload_url }}
-#        asset_path: ./docker/image/lib/kinesis-mock.jar
-#        asset_name: kinesis-mock.jar
-#        asset_content_type: application/java-archive
+    - name: Push to registry
+      run: docker push ghcr.io/etspaceman/kinesis-mock:${{ github.event.release.tag_name }}
+    - name: Upload JAR To Release
+      id: upload-release-asset 
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./docker/image/lib/kinesis-mock.jar
+        asset_name: kinesis-mock.jar
+        asset_content_type: application/java-archive

--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ You can also leverage the following executable options in the release assets:
 | File | Description | Launching |
 | ---- | ----------- | --------- |
 | kinesis-mock.jar | Executable JAR file that can be run in any environment with JDK 11 | `java -jar ./kinesis-mock.jar` |
-| kinesis-mock-linux-amd64-dynamic | GraalVM Native Image executable for Linux. Loads dependencies like libc at runtime. | `./kinesis-mock-linux-amd64-dynamic` |
+| kinesis-mock-linux-amd64-dynamic | GraalVM Native Image executable for Linux. Loads dependencies like libc at runtime. Best for non-docker runtimes. | `./kinesis-mock-linux-amd64-dynamic` |
 | kinesis-mock-linux-amd64-static | GraalVM Native Image executable for Linux. All dependencies are statically provided. Good for docker images. | `./kinesis-mock-linux-amd64-static` |
 | kinesis-mock-linux-amd64-mostly-static | GraalVM Native Image executable for Linux. Most dependencies are statically provided, except libc. Good for docker images. | `./kinesis-mock-linux-amd64-static` |
-| kinesis-mock-macos-amd64-dynamic | GraalVM Native Image executable for MacOS. Loads dependencies like libc at runtime. | `./kinesis-mock-macos-amd64-dynamic` |
-| kinesis-mock-dynamic.exe | GraalVM Native Image executable for Windows. Loads dependencies like libc at runtime. | `./kinesis-mock-dynamic.exe` |
+| kinesis-mock-macos-amd64-dynamic | GraalVM Native Image executable for MacOS. Loads dependencies like libc at runtime. Best for non-docker runtimes.  | `./kinesis-mock-macos-amd64-dynamic` |
+| kinesis-mock-dynamic.exe | GraalVM Native Image executable for Windows. Loads dependencies like libc at runtime. Best for non-docker runtimes. | `./kinesis-mock-dynamic.exe` |
 | kinesis-mock-mostly-static.exe | GraalVM Native Image executable for Windows. Most dependencies are statically provided, except libc. Good for docker images. | `./kinesis-mock-mostly-static.exe` |
 
 See [the GraalVM documentation](https://www.graalvm.org/reference-manual/native-image/StaticImages/) for more information about static vs non-static Native Image distributions.

--- a/README.md
+++ b/README.md
@@ -30,21 +30,16 @@ docker run -p 4567:4567 -p 4568:4568 ghcr.io/etspaceman/kinesis-mock:0.0.10
 
 You can also leverage the following executable options in the release assets:
 
-```shell
-java -jar ./kinesis-mock.jar
-```
+| File | Description | Launching |
+| kinesis-mock.jar | Executable JAR file that can be run in any environment with JDK 11 | `java -jar ./kinesis-mock.jar` |
+| kinesis-mock-linux-amd64-dynamic | GraalVM Native Image executable for Linux. Loads dependencies like libc at runtime. | `./kinesis-mock-linux-amd64-dynamic` |
+| kinesis-mock-linux-amd64-static | GraalVM Native Image executable for Linux. All dependencies are statically provided. Good for docker images. | `./kinesis-mock-linux-amd64-static` |
+| kinesis-mock-linux-amd64-mostly-static | GraalVM Native Image executable for Linux. Most dependencies are statically provided, except libc. Good for docker images. | `./kinesis-mock-linux-amd64-static` |
+| kinesis-mock-macos-amd64-dynamic | GraalVM Native Image executable for MacOS. Loads dependencies like libc at runtime. | `./kinesis-mock-macos-amd64-dynamic` |
+| kinesis-mock-dynamic.exe | GraalVM Native Image executable for Windows. Loads dependencies like libc at runtime. | `./kinesis-mock-dynamic.exe` |
+| kinesis-mock-mostly-static.exe | GraalVM Native Image executable for Windows. Most dependencies are statically provided, except libc. Good for docker images. | `./kinesis-mock-mostly-static.exe` |
 
-```shell
-kinesis-mock-linux-amd64
-```
-
-```shell
-kinesis-mock-macos-amd64
-```
-
-```powershell
-kinesis-mock.exe
-```
+See [the GraalVM documentation](https://www.graalvm.org/reference-manual/native-image/StaticImages/) for more information about static vs non-static Native Image distributions.
 
 # Service Configuration
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ docker run -p 4567:4567 -p 4568:4568 ghcr.io/etspaceman/kinesis-mock:0.0.10
 You can also leverage the following executable options in the release assets:
 
 | File | Description | Launching |
+| ---- | ----------- | --------- |
 | kinesis-mock.jar | Executable JAR file that can be run in any environment with JDK 11 | `java -jar ./kinesis-mock.jar` |
 | kinesis-mock-linux-amd64-dynamic | GraalVM Native Image executable for Linux. Loads dependencies like libc at runtime. | `./kinesis-mock-linux-amd64-dynamic` |
 | kinesis-mock-linux-amd64-static | GraalVM Native Image executable for Linux. All dependencies are statically provided. Good for docker images. | `./kinesis-mock-linux-amd64-static` |

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,6 +22,7 @@ RUN curl -L -o zlib.tar.gz https://zlib.net/zlib-1.2.11.tar.gz && \
 
 ARG DOCKER_SERVICE_JAR
 ARG STATIC_TYPE
+ENV STATIC_TYPE=${STATIC_TYPE}
 COPY ${DOCKER_SERVICE_JAR} ./kinesis-mock.jar
 COPY graal ./graal
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,28 +21,11 @@ RUN curl -L -o zlib.tar.gz https://zlib.net/zlib-1.2.11.tar.gz && \
     cd / && rm -rf /zlib && rm -f /zlib.tar.gz
 
 ARG DOCKER_SERVICE_JAR
+ARG STATIC_TYPE
 COPY ${DOCKER_SERVICE_JAR} ./kinesis-mock.jar
 COPY graal ./graal
 
-RUN native-image \
-    --no-server \
-    --static \
-    --libc=musl \
-    -J-Xmx7G \
-    --no-fallback \
-    --verbose \
-    --enable-all-security-services \
-    --enable-url-protocols=http,https \
-    --initialize-at-build-time=scala \
-    -H:ReflectionConfigurationFiles=graal/reflect-config.json \
-    -H:ResourceConfigurationFiles=graal/resource-config.json \
-    -H:+ReportExceptionStackTraces \
-    -H:+AddAllCharsets \
-    --report-unsupported-elements-at-runtime \
-    --allow-incomplete-classpath \
-    --install-exit-handlers \
-    -jar kinesis-mock.jar \
-    kinesis-mock-native
+RUN ./graal/buildNativeImageLinux.sh
 
 RUN microdnf install xz && \
     curl -sL -o - https://github.com/upx/upx/releases/download/v3.96/upx-3.96-amd64_linux.tar.xz | tar xJ && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,11 +22,10 @@ RUN curl -L -o zlib.tar.gz https://zlib.net/zlib-1.2.11.tar.gz && \
 
 ARG DOCKER_SERVICE_JAR
 ARG STATIC_TYPE
-ENV STATIC_TYPE=${STATIC_TYPE}
 COPY ${DOCKER_SERVICE_JAR} ./kinesis-mock.jar
 COPY graal ./graal
 
-RUN ./graal/buildNativeImageLinux.sh
+RUN ./graal/buildNativeImageLinux.sh ${STATIC_TYPE}
 
 RUN microdnf install xz && \
     curl -sL -o - https://github.com/upx/upx/releases/download/v3.96/upx-3.96-amd64_linux.tar.xz | tar xJ && \

--- a/graal/buildNativeImage.ps1
+++ b/graal/buildNativeImage.ps1
@@ -1,9 +1,10 @@
 $JAR_FILE = $env:JAR_FILE;
 $OUTPUT_FILE = $env:OUTPUT_FILE;
+$STATIC_ARG = if($env:STATIC_TYPE -eq "mostly-static") { "-H:+StaticExecutableWithDynamicLibC" } else { "" }
 
 native-image.cmd `
     --no-server `
-    -H:+StaticExecutableWithDynamicLibC `
+    $STATIC_ARG `
     -J-Xmx7G `
     --no-fallback `
     --verbose `

--- a/graal/buildNativeImageLinux.sh
+++ b/graal/buildNativeImageLinux.sh
@@ -1,4 +1,4 @@
-STATIC_TYPE=${STATIC_TYPE:-static}
+STATIC_TYPE=${1:-static}
 
 if [[ $STATIC_TYPE = "static" ]]; then
     STATIC_ARG="--static --libc=musl"

--- a/graal/buildNativeImageLinux.sh
+++ b/graal/buildNativeImageLinux.sh
@@ -1,0 +1,28 @@
+STATIC_TYPE=${STATIC_TYPE:-static}
+
+if [[ $STATIC_TYPE = "static" ]]; then
+    STATIC_ARG="--static --libc=musl"
+elif [[ $STATIC_TYPE = "mostly-static" ]]; then
+    STATIC_ARG="-H:+StaticExecutableWithDynamicLibC"
+else
+    STATIC_ARG=""
+fi
+
+native-image \
+    --no-server \
+    ${STATIC_ARG} \
+    -J-Xmx7G \
+    --no-fallback \
+    --verbose \
+    --enable-all-security-services \
+    --enable-url-protocols=http,https \
+    --initialize-at-build-time=scala \
+    -H:ReflectionConfigurationFiles=graal/reflect-config.json \
+    -H:ResourceConfigurationFiles=graal/resource-config.json \
+    -H:+ReportExceptionStackTraces \
+    -H:+AddAllCharsets \
+    --report-unsupported-elements-at-runtime \
+    --allow-incomplete-classpath \
+    --install-exit-handlers \
+    -jar kinesis-mock.jar \
+    kinesis-mock-native

--- a/project/DockerComposePlugin.scala
+++ b/project/DockerComposePlugin.scala
@@ -42,7 +42,8 @@ object DockerComposePlugin extends AutoPlugin {
         None,
         "DOCKER_TAG_VERSION" -> (ThisBuild / version).value,
         "DOCKER_NET_NAME" -> networkName.value,
-        "COMPOSE_PROJECT_NAME" -> composeProjectName.value
+        "COMPOSE_PROJECT_NAME" -> composeProjectName.value,
+        "STATIC_TYPE" -> staticType.value
       ).!
       if (res != 0)
         throw new IllegalStateException(s"docker-compose up returned $res")
@@ -66,7 +67,8 @@ object DockerComposePlugin extends AutoPlugin {
       None,
       "DOCKER_TAG_VERSION" -> (ThisBuild / version).value,
       "DOCKER_NET_NAME" -> networkName.value,
-      "COMPOSE_PROJECT_NAME" -> composeProjectName.value
+      "COMPOSE_PROJECT_NAME" -> composeProjectName.value,
+      "STATIC_TYPE" -> staticType.value
     ).!
     if (res != 0)
       throw new IllegalStateException(s"docker-compose kill returned $res")
@@ -81,7 +83,8 @@ object DockerComposePlugin extends AutoPlugin {
       None,
       "DOCKER_TAG_VERSION" -> (ThisBuild / version).value,
       "DOCKER_NET_NAME" -> networkName.value,
-      "COMPOSE_PROJECT_NAME" -> composeProjectName.value
+      "COMPOSE_PROJECT_NAME" -> composeProjectName.value,
+      "STATIC_TYPE" -> staticType.value
     ).!
     if (res != 0)
       throw new IllegalStateException(s"docker-compose down returned $res")
@@ -104,7 +107,8 @@ object DockerComposePlugin extends AutoPlugin {
       None,
       "DOCKER_TAG_VERSION" -> (ThisBuild / version).value,
       "DOCKER_NET_NAME" -> networkName.value,
-      "COMPOSE_PROJECT_NAME" -> composeProjectName.value
+      "COMPOSE_PROJECT_NAME" -> composeProjectName.value,
+      "STATIC_TYPE" -> staticType.value
     ).!
     if (res != 0)
       throw new IllegalStateException(s"docker-compose logs returned $res")
@@ -120,7 +124,8 @@ object DockerComposePlugin extends AutoPlugin {
       None,
       "DOCKER_TAG_VERSION" -> (ThisBuild / version).value,
       "DOCKER_NET_NAME" -> networkName.value,
-      "COMPOSE_PROJECT_NAME" -> composeProjectName.value
+      "COMPOSE_PROJECT_NAME" -> composeProjectName.value,
+      "STATIC_TYPE" -> staticType.value
     ).!
     if (res != 0)
       throw new IllegalStateException(s"docker-compose ps -a returned $res")
@@ -149,6 +154,7 @@ object DockerComposePlugin extends AutoPlugin {
         .getOrElse("DOCKER_NET_NAME", "kinesis_mock_network"),
       composeProjectName := sys.env
         .getOrElse("COMPOSE_PROJECT_NAME", "kinesis-mock"),
+      staticType := sys.env.getOrElse("STATIC_TYPE", "static"),
       buildImage := true
     )
 
@@ -168,6 +174,10 @@ object DockerComposePluginKeys {
   val buildImage = settingKey[Boolean](
     "Determines if dockerComposeUp should also build a docker image via the DockerImagePlugin"
   )
+
+  val staticType =
+    settingKey[String]("Static type to use when building the native image. 'static', 'mostly-static' and 'dynamic' are the acceptable values.")
+
   val createNetwork = taskKey[Unit]("Creates a docker network")
   val removeNetwork = taskKey[Unit]("Removes a docker network")
 

--- a/project/DockerComposePlugin.scala
+++ b/project/DockerComposePlugin.scala
@@ -30,6 +30,22 @@ object DockerComposePlugin extends AutoPlugin {
 
   val composeFile: Def.Initialize[Task[String]] =
     Def.task(s"${composeFileLocation.value}docker-compose.yml")
+  
+  val dockerComposeBuildTask: Def.Initialize[Task[Unit]] = Def.task {
+    val log = sbt.Keys.streams.value.log
+      val cmd =
+        s"docker-compose -f ${composeFile.value} build --build-arg STATIC_TYPE=${staticType.value}"
+      log.info(s"Running $cmd")
+      val res = Process(
+        cmd,
+        None,
+        "DOCKER_TAG_VERSION" -> (ThisBuild / version).value,
+        "DOCKER_NET_NAME" -> networkName.value,
+        "COMPOSE_PROJECT_NAME" -> composeProjectName.value
+      ).!
+      if (res != 0)
+        throw new IllegalStateException(s"docker-compose up returned $res")
+  }
 
   val dockerComposeUpBaseTask: Def.Initialize[Task[Unit]] = Def
     .task {
@@ -42,13 +58,12 @@ object DockerComposePlugin extends AutoPlugin {
         None,
         "DOCKER_TAG_VERSION" -> (ThisBuild / version).value,
         "DOCKER_NET_NAME" -> networkName.value,
-        "COMPOSE_PROJECT_NAME" -> composeProjectName.value,
-        "STATIC_TYPE" -> staticType.value
+        "COMPOSE_PROJECT_NAME" -> composeProjectName.value
       ).!
       if (res != 0)
         throw new IllegalStateException(s"docker-compose up returned $res")
     }
-    .dependsOn(createNetworkTask)
+    .dependsOn(createNetworkTask, dockerComposeBuildTask)
 
   val dockerComposeUpTask: Def.Initialize[Task[Unit]] = Def.taskDyn {
     if (buildImage.value) {
@@ -67,8 +82,7 @@ object DockerComposePlugin extends AutoPlugin {
       None,
       "DOCKER_TAG_VERSION" -> (ThisBuild / version).value,
       "DOCKER_NET_NAME" -> networkName.value,
-      "COMPOSE_PROJECT_NAME" -> composeProjectName.value,
-      "STATIC_TYPE" -> staticType.value
+      "COMPOSE_PROJECT_NAME" -> composeProjectName.value
     ).!
     if (res != 0)
       throw new IllegalStateException(s"docker-compose kill returned $res")
@@ -83,8 +97,7 @@ object DockerComposePlugin extends AutoPlugin {
       None,
       "DOCKER_TAG_VERSION" -> (ThisBuild / version).value,
       "DOCKER_NET_NAME" -> networkName.value,
-      "COMPOSE_PROJECT_NAME" -> composeProjectName.value,
-      "STATIC_TYPE" -> staticType.value
+      "COMPOSE_PROJECT_NAME" -> composeProjectName.value
     ).!
     if (res != 0)
       throw new IllegalStateException(s"docker-compose down returned $res")
@@ -107,8 +120,7 @@ object DockerComposePlugin extends AutoPlugin {
       None,
       "DOCKER_TAG_VERSION" -> (ThisBuild / version).value,
       "DOCKER_NET_NAME" -> networkName.value,
-      "COMPOSE_PROJECT_NAME" -> composeProjectName.value,
-      "STATIC_TYPE" -> staticType.value
+      "COMPOSE_PROJECT_NAME" -> composeProjectName.value
     ).!
     if (res != 0)
       throw new IllegalStateException(s"docker-compose logs returned $res")
@@ -124,8 +136,7 @@ object DockerComposePlugin extends AutoPlugin {
       None,
       "DOCKER_TAG_VERSION" -> (ThisBuild / version).value,
       "DOCKER_NET_NAME" -> networkName.value,
-      "COMPOSE_PROJECT_NAME" -> composeProjectName.value,
-      "STATIC_TYPE" -> staticType.value
+      "COMPOSE_PROJECT_NAME" -> composeProjectName.value
     ).!
     if (res != 0)
       throw new IllegalStateException(s"docker-compose ps -a returned $res")
@@ -148,6 +159,7 @@ object DockerComposePlugin extends AutoPlugin {
       dockerComposeDown := dockerComposeDownTask.value,
       dockerComposeLogs := dockerComposeLogsTask.value,
       dockerComposePs := dockerComposePsTask.value,
+      dockerComposeBuild := dockerComposeBuildTask.value,
       dockerComposeTestQuick := dockerComposeTestQuickTask(configuration).value,
       composeFileLocation := "docker/",
       networkName := sys.env
@@ -193,4 +205,6 @@ object DockerComposePluginKeys {
     taskKey[Unit]("Runs `docker-compose -f <file> logs` for the scope")
   val dockerComposePs =
     taskKey[Unit]("Runs `docker-compose -f <file> ps -a` for the scope")
+  val dockerComposeBuild =
+    taskKey[Unit]("Runs `docker-compose -f <file> build` for the scope")
 }

--- a/project/DockerImagePlugin.scala
+++ b/project/DockerImagePlugin.scala
@@ -20,6 +20,7 @@ object DockerImagePlugin extends AutoPlugin {
     val cmd =
       s"""docker build \\
          |  --build-arg DOCKER_SERVICE_JAR=${jarLocation.value + name.value}.jar \\
+         |  --build-arg STATIC_TYPE=${staticType.value} \\
          |  -f ${dockerfileLocation.value + dockerfile.value} \\
          |  -t ${dockerTagTask.value} \\
          |  .""".stripMargin
@@ -57,7 +58,8 @@ object DockerImagePlugin extends AutoPlugin {
       dockerfile := "Dockerfile",
       assembly / assemblyOutputPath := file(
         s"${jarLocation.value + name.value}.jar"
-      )
+      ),
+      staticType := sys.env.getOrElse("STATIC_TYPE", "static"),
     )
 }
 
@@ -75,6 +77,8 @@ object DockerImagePluginKeys {
   val dockerfileLocation =
     settingKey[String]("Location of the Dockerfile, e.g. docker/")
   val dockerfile = settingKey[String]("Dockerfile to use, e.g. Dockerfile")
+    val staticType =
+    settingKey[String]("Static type to use when building the native image. 'static', 'mostly-static' and 'dynamic' are the acceptable values.")
   val buildDockerImage =
     taskKey[Unit]("Builds the docker images defined in the project.")
   val packageAndBuildDockerImage = taskKey[Unit](

--- a/project/DockerImagePlugin.scala
+++ b/project/DockerImagePlugin.scala
@@ -59,7 +59,7 @@ object DockerImagePlugin extends AutoPlugin {
       assembly / assemblyOutputPath := file(
         s"${jarLocation.value + name.value}.jar"
       ),
-      staticType := sys.env.getOrElse("STATIC_TYPE", "static"),
+      staticType := sys.env.getOrElse("STATIC_TYPE", "static")
     )
 }
 
@@ -77,8 +77,10 @@ object DockerImagePluginKeys {
   val dockerfileLocation =
     settingKey[String]("Location of the Dockerfile, e.g. docker/")
   val dockerfile = settingKey[String]("Dockerfile to use, e.g. Dockerfile")
-    val staticType =
-    settingKey[String]("Static type to use when building the native image. 'static', 'mostly-static' and 'dynamic' are the acceptable values.")
+  val staticType =
+    settingKey[String](
+      "Static type to use when building the native image. 'static', 'mostly-static' and 'dynamic' are the acceptable values."
+    )
   val buildDockerImage =
     taskKey[Unit]("Builds the docker images defined in the project.")
   val packageAndBuildDockerImage = taskKey[Unit](


### PR DESCRIPTION
## Changes Introduced

Provides static, mostly-static and non-static native image executables so users can pick which one is appropriate for them.

## Applicable linked issues

#11 

## Checklist (check all that apply)

- [X] This change maintains backwards compatibility
- [ ] I have introduced tests for all new features and changes
- [X] I have added documentation covering all new features and changes
- [X] This pull-request is ready for review