### PR TITLE
Fix ListStreamConsumers Bug

### DIFF
--- a/src/main/scala/kinesis/mock/api/ListStreamConsumersRequest.scala
+++ b/src/main/scala/kinesis/mock/api/ListStreamConsumersRequest.scala
@@ -53,7 +53,7 @@ final case class ListStreamConsumersRequest(
                       Math.min(firstIndex + limit, lastConsumerIndex + 1)
                     val consumers = allConsumers.slice(firstIndex, lastIndex)
                     val ntUpdated =
-                      if (lastConsumerIndex == lastIndex) None
+                      if (lastConsumerIndex == lastIndex || consumers.isEmpty) None
                       else Some(consumers.last.consumerName)
                     ListStreamConsumersResponse(consumers, ntUpdated)
 
@@ -66,7 +66,7 @@ final case class ListStreamConsumersRequest(
                       Math.min(limit, lastConsumerIndex + 1)
                     val consumers = allConsumers.take(limit)
                     val nextToken =
-                      if (lastConsumerIndex == lastIndex) None
+                      if (lastConsumerIndex == lastIndex || consumers.isEmpty) None
                       else Some(consumers.last.consumerName)
                     ListStreamConsumersResponse(consumers, nextToken)
                 }

--- a/src/main/scala/kinesis/mock/api/ListStreamConsumersRequest.scala
+++ b/src/main/scala/kinesis/mock/api/ListStreamConsumersRequest.scala
@@ -53,7 +53,8 @@ final case class ListStreamConsumersRequest(
                       Math.min(firstIndex + limit, lastConsumerIndex + 1)
                     val consumers = allConsumers.slice(firstIndex, lastIndex)
                     val ntUpdated =
-                      if (lastConsumerIndex == lastIndex || consumers.isEmpty) None
+                      if (lastConsumerIndex == lastIndex || consumers.isEmpty)
+                        None
                       else Some(consumers.last.consumerName)
                     ListStreamConsumersResponse(consumers, ntUpdated)
 
@@ -66,7 +67,8 @@ final case class ListStreamConsumersRequest(
                       Math.min(limit, lastConsumerIndex + 1)
                     val consumers = allConsumers.take(limit)
                     val nextToken =
-                      if (lastConsumerIndex == lastIndex || consumers.isEmpty) None
+                      if (lastConsumerIndex == lastIndex || consumers.isEmpty)
+                        None
                       else Some(consumers.last.consumerName)
                     ListStreamConsumersResponse(consumers, nextToken)
                 }

--- a/src/test/scala/kinesis/mock/api/ListStreamConsumersTests.scala
+++ b/src/test/scala/kinesis/mock/api/ListStreamConsumersTests.scala
@@ -56,6 +56,28 @@ class ListStreamConsumersTests
       )
   })
 
+  test("It should list consumers when consumers are empty")(PropF.forAllF {
+    (
+        streamName: StreamName,
+        awsRegion: AwsRegion,
+        awsAccountId: AwsAccountId
+    ) =>
+      val (streams, _) =
+        Streams.empty.addStream(100, streamName, awsRegion, awsAccountId)
+
+      val streamArn = streams.streams(streamName).streamArn
+
+      for {
+        streamsRef <- Ref.of[IO, Streams](streams)
+        req = ListStreamConsumersRequest(None, None, streamArn, None)
+        res <- req.listStreamConsumers(streamsRef)
+
+      } yield assert(
+        res.isValid && res.exists(_.consumers.isEmpty),
+        s"req: $req\nres: $res"
+      )
+  })
+
   test("It should paginate properly")(PropF.forAllF {
     (
         streamName: StreamName,


### PR DESCRIPTION
## Changes Introduced

If ListStreamConsumers was called when no consumers existed on the stream, there would be an unhandled error because a `last` call would be called on an empty list.

## Applicable linked issues

## Checklist (check all that apply)

- [X] This change maintains backwards compatibility
- [X] I have introduced tests for all new features and changes
- [ ] I have added documentation covering all new features and changes
- [X] This pull-request is ready for review