### PR TITLE
BugFix: DescribeStreamConsumer response needs to include StreamARN

### DIFF
--- a/src/fun/scala/kinesis/mock/DescribeStreamConsumerTests.scala
+++ b/src/fun/scala/kinesis/mock/DescribeStreamConsumerTests.scala
@@ -38,7 +38,8 @@ class DescribeStreamConsumerTests
           .consumerCreationTimestamp() &&
         res
           .consumerDescription()
-          .consumerStatus == registerRes.consumer().consumerStatus(),
+          .consumerStatus == registerRes.consumer().consumerStatus() &&
+        res.consumerDescription().streamARN() == streamArn,
       s"$res\n$registerRes"
     )
   }

--- a/src/fun/scala/kinesis/mock/ListStreamConsumersTests.scala
+++ b/src/fun/scala/kinesis/mock/ListStreamConsumersTests.scala
@@ -42,7 +42,7 @@ class ListStreamConsumersTests
         .toList
         .sortBy(_.consumerName())
         .map(x =>
-          models.Consumer(
+          models.ConsumerSummary(
             x.consumerARN(),
             x.consumerCreationTimestamp(),
             models.ConsumerName(x.consumerName()),
@@ -52,7 +52,7 @@ class ListStreamConsumersTests
         .map(_.consumer())
         .sortBy(_.consumerName())
         .map(x =>
-          models.Consumer(
+          models.ConsumerSummary(
             x.consumerARN(),
             x.consumerCreationTimestamp(),
             models.ConsumerName(x.consumerName()),

--- a/src/main/scala/kinesis/mock/api/ListStreamConsumersRequest.scala
+++ b/src/main/scala/kinesis/mock/api/ListStreamConsumersRequest.scala
@@ -56,7 +56,10 @@ final case class ListStreamConsumersRequest(
                       if (lastConsumerIndex == lastIndex || consumers.isEmpty)
                         None
                       else Some(consumers.last.consumerName)
-                    ListStreamConsumersResponse(consumers, ntUpdated)
+                    ListStreamConsumersResponse(
+                      consumers.map(ConsumerSummary.fromConsumer),
+                      ntUpdated
+                    )
 
                   case None =>
                     val allConsumers = stream.consumers.values.toList
@@ -70,7 +73,10 @@ final case class ListStreamConsumersRequest(
                       if (lastConsumerIndex == lastIndex || consumers.isEmpty)
                         None
                       else Some(consumers.last.consumerName)
-                    ListStreamConsumersResponse(consumers, nextToken)
+                    ListStreamConsumersResponse(
+                      consumers.map(ConsumerSummary.fromConsumer),
+                      nextToken
+                    )
                 }
               )
             )

--- a/src/main/scala/kinesis/mock/api/ListStreamConsumersResponse.scala
+++ b/src/main/scala/kinesis/mock/api/ListStreamConsumersResponse.scala
@@ -8,36 +8,44 @@ import io.circe
 import kinesis.mock.models._
 
 final case class ListStreamConsumersResponse(
-    consumers: List[Consumer],
+    consumers: List[ConsumerSummary],
     nextToken: Option[ConsumerName]
 )
 
 object ListStreamConsumersResponse {
   def listStreamConsumersResponseCirceEncoder(implicit
-      EC: circe.Encoder[Consumer]
+      EC: circe.Encoder[ConsumerSummary]
   ): circe.Encoder[ListStreamConsumersResponse] =
     circe.Encoder.forProduct2("Consumers", "NextToken")(x =>
       (x.consumers, x.nextToken)
     )
 
   def listStreamConsumersResponseCirceDecoder(implicit
-      DC: circe.Decoder[Consumer]
+      DC: circe.Decoder[ConsumerSummary]
   ): circe.Decoder[ListStreamConsumersResponse] =
     x =>
       for {
-        consumers <- x.downField("Consumers").as[List[Consumer]]
+        consumers <- x.downField("Consumers").as[List[ConsumerSummary]]
         nextToken <- x.downField("NextToken").as[Option[ConsumerName]]
       } yield ListStreamConsumersResponse(consumers, nextToken)
 
   implicit val listStreamConsumersResponseEncoder
       : Encoder[ListStreamConsumersResponse] = Encoder.instance(
-    listStreamConsumersResponseCirceEncoder(Encoder[Consumer].circeEncoder),
-    listStreamConsumersResponseCirceEncoder(Encoder[Consumer].circeCborEncoder)
+    listStreamConsumersResponseCirceEncoder(
+      Encoder[ConsumerSummary].circeEncoder
+    ),
+    listStreamConsumersResponseCirceEncoder(
+      Encoder[ConsumerSummary].circeCborEncoder
+    )
   )
   implicit val listStreamConsumersResponseDecoder
       : Decoder[ListStreamConsumersResponse] = Decoder.instance(
-    listStreamConsumersResponseCirceDecoder(Decoder[Consumer].circeDecoder),
-    listStreamConsumersResponseCirceDecoder(Decoder[Consumer].circeCborDecoder)
+    listStreamConsumersResponseCirceDecoder(
+      Decoder[ConsumerSummary].circeDecoder
+    ),
+    listStreamConsumersResponseCirceDecoder(
+      Decoder[ConsumerSummary].circeCborDecoder
+    )
   )
   implicit val listStreamConusmerResponseEq: Eq[ListStreamConsumersResponse] =
     (x, y) => x.consumers === y.consumers && x.nextToken == y.nextToken

--- a/src/main/scala/kinesis/mock/api/RegisterStreamConsumerRequest.scala
+++ b/src/main/scala/kinesis/mock/api/RegisterStreamConsumerRequest.scala
@@ -61,7 +61,11 @@ final case class RegisterStreamConsumerRequest(
                   )
               )
             )
-            .as(RegisterStreamConsumerResponse(consumer))
+            .as(
+              RegisterStreamConsumerResponse(
+                ConsumerSummary.fromConsumer(consumer)
+              )
+            )
         }
     }
 }

--- a/src/main/scala/kinesis/mock/api/RegisterStreamConsumerResponse.scala
+++ b/src/main/scala/kinesis/mock/api/RegisterStreamConsumerResponse.scala
@@ -7,30 +7,34 @@ import io.circe
 
 import kinesis.mock.models._
 
-final case class RegisterStreamConsumerResponse(consumer: Consumer)
+final case class RegisterStreamConsumerResponse(consumer: ConsumerSummary)
 
 object RegisterStreamConsumerResponse {
   def registerStreamConsumerResponseCirceEncoder(implicit
-      EC: circe.Encoder[Consumer]
+      EC: circe.Encoder[ConsumerSummary]
   ): circe.Encoder[RegisterStreamConsumerResponse] =
     circe.Encoder.forProduct1("Consumer")(_.consumer)
   def registerStreamConsumerResponseCirceDecoder(implicit
-      DC: circe.Decoder[Consumer]
+      DC: circe.Decoder[ConsumerSummary]
   ): circe.Decoder[RegisterStreamConsumerResponse] = _.downField("Consumer")
-    .as[Consumer]
+    .as[ConsumerSummary]
     .map(RegisterStreamConsumerResponse.apply)
   implicit val registerStreamConsumerResponseEncoder
       : Encoder[RegisterStreamConsumerResponse] = Encoder.instance(
-    registerStreamConsumerResponseCirceEncoder(Encoder[Consumer].circeEncoder),
     registerStreamConsumerResponseCirceEncoder(
-      Encoder[Consumer].circeCborEncoder
+      Encoder[ConsumerSummary].circeEncoder
+    ),
+    registerStreamConsumerResponseCirceEncoder(
+      Encoder[ConsumerSummary].circeCborEncoder
     )
   )
   implicit val registerStreamConsumerResponseDecoder
       : Decoder[RegisterStreamConsumerResponse] = Decoder.instance(
-    registerStreamConsumerResponseCirceDecoder(Decoder[Consumer].circeDecoder),
     registerStreamConsumerResponseCirceDecoder(
-      Decoder[Consumer].circeCborDecoder
+      Decoder[ConsumerSummary].circeDecoder
+    ),
+    registerStreamConsumerResponseCirceDecoder(
+      Decoder[ConsumerSummary].circeCborDecoder
     )
   )
   implicit val registerStreamConsumerResponseEq

--- a/src/main/scala/kinesis/mock/cache/Cache.scala
+++ b/src/main/scala/kinesis/mock/cache/Cache.scala
@@ -441,10 +441,13 @@ class Cache private (
                               x.updateStream(
                                 stream.copy(consumers =
                                   stream.consumers ++ List(
-                                    r.consumer.consumerName -> r.consumer
-                                      .copy(consumerStatus =
-                                        ConsumerStatus.ACTIVE
-                                      )
+                                    r.consumer.consumerName -> Consumer(
+                                      r.consumer.consumerArn,
+                                      r.consumer.consumerCreationTimestamp,
+                                      r.consumer.consumerName,
+                                      ConsumerStatus.ACTIVE,
+                                      req.streamArn
+                                    )
                                   )
                                 )
                               )

--- a/src/main/scala/kinesis/mock/models/Consumer.scala
+++ b/src/main/scala/kinesis/mock/models/Consumer.scala
@@ -12,7 +12,8 @@ final case class Consumer(
     consumerArn: String,
     consumerCreationTimestamp: Instant,
     consumerName: ConsumerName,
-    consumerStatus: ConsumerStatus
+    consumerStatus: ConsumerStatus,
+    streamArn: String
 )
 
 object Consumer {
@@ -22,22 +23,25 @@ object Consumer {
       s"$streamArn/consumer/$consumerName:${consumerCreationTimestamp.getEpochSecond}",
       consumerCreationTimestamp,
       consumerName,
-      ConsumerStatus.CREATING
+      ConsumerStatus.CREATING,
+      streamArn
     )
   }
   def consumerCirceEncoder(implicit
       EI: circe.Encoder[Instant]
-  ): circe.Encoder[Consumer] = circe.Encoder.forProduct4(
+  ): circe.Encoder[Consumer] = circe.Encoder.forProduct5(
     "ConsumerARN",
     "ConsumerCreationTimestamp",
     "ConsumerName",
-    "ConsumerStatus"
+    "ConsumerStatus",
+    "StreamARN"
   )(x =>
     (
       x.consumerArn,
       x.consumerCreationTimestamp,
       x.consumerName,
-      x.consumerStatus
+      x.consumerStatus,
+      x.streamArn
     )
   )
 
@@ -51,11 +55,13 @@ object Consumer {
         .as[Instant]
       consumerName <- x.downField("ConsumerName").as[ConsumerName]
       consumerStatus <- x.downField("ConsumerStatus").as[ConsumerStatus]
+      streamArn <- x.downField("StreamARN").as[String]
     } yield Consumer(
       consumerArn,
       consumerCreationTimestamp,
       consumerName,
-      consumerStatus
+      consumerStatus,
+      streamArn
     )
   }
 
@@ -73,5 +79,6 @@ object Consumer {
     x.consumerArn == y.consumerArn &&
       x.consumerCreationTimestamp.getEpochSecond == y.consumerCreationTimestamp.getEpochSecond &&
       x.consumerName == y.consumerName &&
-      x.consumerStatus == y.consumerStatus
+      x.consumerStatus == y.consumerStatus &&
+      x.streamArn == y.streamArn
 }

--- a/src/main/scala/kinesis/mock/models/ConsumerSummary.scala
+++ b/src/main/scala/kinesis/mock/models/ConsumerSummary.scala
@@ -1,0 +1,76 @@
+package kinesis.mock
+package models
+
+import java.time.Instant
+
+import cats.kernel.Eq
+import io.circe
+
+import kinesis.mock.instances.circe._
+
+final case class ConsumerSummary(
+    consumerArn: String,
+    consumerCreationTimestamp: Instant,
+    consumerName: ConsumerName,
+    consumerStatus: ConsumerStatus
+)
+
+object ConsumerSummary {
+  def fromConsumer(consumer: Consumer): ConsumerSummary = ConsumerSummary(
+    consumer.consumerArn,
+    consumer.consumerCreationTimestamp,
+    consumer.consumerName,
+    consumer.consumerStatus
+  )
+  def consumerSummaryCirceEncoder(implicit
+      EI: circe.Encoder[Instant]
+  ): circe.Encoder[ConsumerSummary] = circe.Encoder.forProduct4(
+    "ConsumerARN",
+    "ConsumerCreationTimestamp",
+    "ConsumerName",
+    "ConsumerStatus"
+  )(x =>
+    (
+      x.consumerArn,
+      x.consumerCreationTimestamp,
+      x.consumerName,
+      x.consumerStatus
+    )
+  )
+
+  def consumerSummaryCirceDecoder(implicit
+      DI: circe.Decoder[Instant]
+  ): circe.Decoder[ConsumerSummary] = { x =>
+    for {
+      consumerArn <- x.downField("ConsumerARN").as[String]
+      consumerCreationTimestamp <- x
+        .downField("ConsumerCreationTimestamp")
+        .as[Instant]
+      consumerName <- x.downField("ConsumerName").as[ConsumerName]
+      consumerStatus <- x.downField("ConsumerStatus").as[ConsumerStatus]
+    } yield ConsumerSummary(
+      consumerArn,
+      consumerCreationTimestamp,
+      consumerName,
+      consumerStatus
+    )
+  }
+
+  implicit val consumerSummaryEncoder: Encoder[ConsumerSummary] =
+    Encoder.instance(
+      consumerSummaryCirceEncoder(instantDoubleCirceEncoder),
+      consumerSummaryCirceEncoder(instantLongCirceEncoder)
+    )
+
+  implicit val consumerSummaryDecoder: Decoder[ConsumerSummary] =
+    Decoder.instance(
+      consumerSummaryCirceDecoder(instantDoubleCirceDecoder),
+      consumerSummaryCirceDecoder(instantLongCirceDecoder)
+    )
+
+  implicit val consumerSummaryEq: Eq[ConsumerSummary] = (x, y) =>
+    x.consumerArn == y.consumerArn &&
+      x.consumerCreationTimestamp.getEpochSecond == y.consumerCreationTimestamp.getEpochSecond &&
+      x.consumerName == y.consumerName &&
+      x.consumerStatus == y.consumerStatus
+}

--- a/src/test/scala/kinesis/mock/api/ListStreamConsumersTests.scala
+++ b/src/test/scala/kinesis/mock/api/ListStreamConsumersTests.scala
@@ -5,6 +5,7 @@ import scala.collection.SortedMap
 
 import cats.effect.IO
 import cats.effect.concurrent.Ref
+import cats.syntax.all._
 import enumeratum.scalacheck._
 import org.scalacheck.Gen
 import org.scalacheck.effect.PropF
@@ -50,7 +51,8 @@ class ListStreamConsumersTests
 
       } yield assert(
         res.isValid && res.exists { response =>
-          consumers.values.toList == response.consumers
+          consumers.values.toList
+            .map(ConsumerSummary.fromConsumer) === response.consumers
         },
         s"req: $req\nres: $res"
       )
@@ -122,9 +124,15 @@ class ListStreamConsumersTests
 
       } yield assert(
         res.isValid && paginatedRes.isValid && res.exists { response =>
-          consumers.values.take(5) == response.consumers
+          consumers.values
+            .take(5)
+            .toList
+            .map(ConsumerSummary.fromConsumer) === response.consumers
         } && paginatedRes.exists { response =>
-          consumers.values.takeRight(5) == response.consumers
+          consumers.values
+            .takeRight(5)
+            .toList
+            .map(ConsumerSummary.fromConsumer) === response.consumers
         },
         s"req: $req\n" +
           s"resCount: ${res.map(_.consumers.length)}\n" +

--- a/src/test/scala/kinesis/mock/cache/DescribeStreamConsumerTests.scala
+++ b/src/test/scala/kinesis/mock/cache/DescribeStreamConsumerTests.scala
@@ -61,7 +61,9 @@ class DescribeStreamConsumerTests
             )
             .rethrow
         } yield assert(
-          res.consumerDescription == registerRes.consumer,
+          ConsumerSummary.fromConsumer(
+            res.consumerDescription
+          ) === registerRes.consumer && res.consumerDescription.streamArn == streamArn,
           s"$registerRes\n$res"
         )
       )

--- a/src/test/scala/kinesis/mock/instances/arbitrary.scala
+++ b/src/test/scala/kinesis/mock/instances/arbitrary.scala
@@ -85,8 +85,13 @@ object arbitrary {
       consumerArn,
       consumerCreationTimestamp,
       consumerName,
-      consumerStatus
+      consumerStatus,
+      streamArn
     )
+  )
+
+  implicit val consumerSummaryArb: Arbitrary[ConsumerSummary] = Arbitrary(
+    consumerArbitrary.arbitrary.map(ConsumerSummary.fromConsumer)
   )
 
   implicit val hashKeyRangeArbitrary: Arbitrary[HashKeyRange] = Arbitrary(
@@ -638,7 +643,7 @@ object arbitrary {
       : Arbitrary[ListStreamConsumersResponse] = Arbitrary(
     for {
       size <- Gen.choose(0, 20)
-      consumers <- Gen.listOfN(size, consumerArbitrary.arbitrary)
+      consumers <- Gen.listOfN(size, consumerSummaryArb.arbitrary)
       nextToken = consumers.lastOption.map(_.consumerName)
     } yield ListStreamConsumersResponse(consumers, nextToken)
   )
@@ -779,7 +784,7 @@ object arbitrary {
 
   implicit val registerStreamConsumerResponseArb
       : Arbitrary[RegisterStreamConsumerResponse] = Arbitrary(
-    consumerArbitrary.arbitrary.map(RegisterStreamConsumerResponse.apply)
+    consumerSummaryArb.arbitrary.map(RegisterStreamConsumerResponse.apply)
   )
 
   implicit val shardIteratorArbitrary: Arbitrary[ShardIterator] = Arbitrary(

--- a/src/test/scala/kinesis/mock/models/ModelsCodecTests.scala
+++ b/src/test/scala/kinesis/mock/models/ModelsCodecTests.scala
@@ -7,6 +7,7 @@ import kinesis.mock.instances.arbitrary._
 
 class ModelsCodecTests extends CodecTests {
   identityLawTest[Consumer]
+  identityLawTest[ConsumerSummary]
   identityLawTest[HashKeyRange]
   identityLawTest[KinesisRecord]
   identityLawTest[Shard]


### PR DESCRIPTION
## Changes Introduced

DescribeStreamConsumer should have StreamARN in its response body

## Applicable linked issues

## Checklist (check all that apply)

- [X] This change maintains backwards compatibility
- [X] I have introduced tests for all new features and changes
- [ ] I have added documentation covering all new features and changes
- [X] This pull-request is ready for review