### PR TITLE
Use ExpiredIteratorException for expired iterators

### DIFF
--- a/src/main/scala/kinesis/mock/KinesisMockException.scala
+++ b/src/main/scala/kinesis/mock/KinesisMockException.scala
@@ -17,6 +17,8 @@ object KinesisMockException {
 
 final case class InvalidArgumentException(msg: String)
     extends KinesisMockException
+final case class ExpiredIteratorException(msg: String)
+    extends KinesisMockException
 final case class LimitExceededException(msg: String)
     extends KinesisMockException
 final case class ResourceInUseException(msg: String)

--- a/src/main/scala/kinesis/mock/models/ShardIterator.scala
+++ b/src/main/scala/kinesis/mock/models/ShardIterator.scala
@@ -55,7 +55,7 @@ final case class ShardIterator(value: String) {
           ).invalidNel
         else Valid(()),
         if (now.toEpochMilli - iteratorTimeMillis.toLong > 300000)
-          InvalidArgumentException(
+          ExpiredIteratorException(
             "The shard iterator has expired. Shard iterators are only valid for 300 seconds"
           ).invalidNel
         else Valid(())


### PR DESCRIPTION
## Changes Introduced

Introduces a new error type, ExpiredIteratorException. This is necessary because the KCL uses this error type to indicate if its shard-iterator needs to be reset:

https://github.com/awslabs/amazon-kinesis-client/blob/master/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisher.java#L460

## Applicable linked issues

N/A

## Checklist (check all that apply)

- [X] This change maintains backwards compatibility
- [ ] I have introduced tests for all new features and changes
- [ ] I have added documentation covering all new features and changes
- [X] This pull-request is ready for review