### PR TITLE
Use getSimpleName in errors

### DIFF
--- a/src/main/scala/kinesis/mock/KinesisMockRoutes.scala
+++ b/src/main/scala/kinesis/mock/KinesisMockRoutes.scala
@@ -454,7 +454,7 @@ object KinesisMockRoutes {
       entityEncoder: EntityEncoder[IO, ErrorResponse]
   ): IO[Response[IO]] =
     BadRequest(
-      ErrorResponse(err.getClass.getName, err.getMessage),
+      ErrorResponse(err.getClass.getSimpleName, err.getMessage),
       responseHeaders: _*
     )
 


### PR DESCRIPTION
## Changes Introduced

The output of error messages in kinesis-mock includes a package name which is incorrect. This change replaces getName with getSimpleName.

## Applicable linked issues

#105 

## Checklist (check all that apply)

- [x] This change maintains backwards compatibility
- [ ] I have introduced tests for all new features and changes
- [ ] I have added documentation covering all new features and changes
- [x] This pull-request is ready for review