### PR TITLE
Remove Shard Semaphores

### DIFF
--- a/src/main/scala/kinesis/mock/models/ShardSemaphoresKey.scala
+++ b/src/main/scala/kinesis/mock/models/ShardSemaphoresKey.scala
@@ -1,3 +1,0 @@
-package kinesis.mock.models
-
-final case class ShardSemaphoresKey(streamName: StreamName, shard: Shard)

--- a/src/main/scala/kinesis/mock/models/StreamData.scala
+++ b/src/main/scala/kinesis/mock/models/StreamData.scala
@@ -65,27 +65,24 @@ object StreamData {
       streamName: StreamName,
       awsRegion: AwsRegion,
       awsAccountId: AwsAccountId
-  ): (StreamData, List[ShardSemaphoresKey]) = {
+  ): StreamData = {
 
     val createTime = Instant.now()
     val shards: SortedMap[Shard, List[KinesisRecord]] =
       Shard.newShards(shardCount, createTime, 0)
-    (
-      StreamData(
-        SortedMap.empty,
-        EncryptionType.NONE,
-        List(ShardLevelMetrics(List.empty)),
-        None,
-        minRetentionPeriod,
-        shards,
-        s"arn:aws:kinesis:${awsRegion.entryName}:$awsAccountId:stream/$streamName",
-        Instant.now(),
-        streamName,
-        StreamStatus.CREATING,
-        Tags.empty,
-        List.empty
-      ),
-      shards.keys.toList.map(shard => ShardSemaphoresKey(streamName, shard))
+    StreamData(
+      SortedMap.empty,
+      EncryptionType.NONE,
+      List(ShardLevelMetrics(List.empty)),
+      None,
+      minRetentionPeriod,
+      shards,
+      s"arn:aws:kinesis:${awsRegion.entryName}:$awsAccountId:stream/$streamName",
+      Instant.now(),
+      streamName,
+      StreamStatus.CREATING,
+      Tags.empty,
+      List.empty
     )
   }
 }

--- a/src/test/scala/kinesis/mock/api/AddTagsToStreamTests.scala
+++ b/src/test/scala/kinesis/mock/api/AddTagsToStreamTests.scala
@@ -22,7 +22,7 @@ class AddTagsToStreamTests
         awsAccountId: AwsAccountId,
         tags: Tags
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
       for {
@@ -44,7 +44,7 @@ class AddTagsToStreamTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
       val tagKey = tagKeyGen.one

--- a/src/test/scala/kinesis/mock/api/DecreaseStreamRetentionPeriodTests.scala
+++ b/src/test/scala/kinesis/mock/api/DecreaseStreamRetentionPeriodTests.scala
@@ -19,7 +19,7 @@ class DecreaseStreamRetentionPeriodTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
       val withIncreasedRetention =
         streams.findAndUpdateStream(streamName)(stream =>
@@ -49,7 +49,7 @@ class DecreaseStreamRetentionPeriodTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
       for {

--- a/src/test/scala/kinesis/mock/api/DeregisterStreamConsumerTests.scala
+++ b/src/test/scala/kinesis/mock/api/DeregisterStreamConsumerTests.scala
@@ -21,7 +21,7 @@ class DeregisterStreamConsumerTests
         awsAccountId: AwsAccountId,
         consumerName: ConsumerName
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
       val updated = streams.findAndUpdateStream(streamName) { stream =>
         stream.copy(
@@ -61,7 +61,7 @@ class DeregisterStreamConsumerTests
         awsAccountId: AwsAccountId,
         consumerName: ConsumerName
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
       val updated = streams.findAndUpdateStream(streamName) { stream =>
@@ -101,7 +101,7 @@ class DeregisterStreamConsumerTests
         awsAccountId: AwsAccountId,
         consumerName: ConsumerName
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
       val updated = streams.findAndUpdateStream(streamName) { stream =>
@@ -135,7 +135,7 @@ class DeregisterStreamConsumerTests
         awsAccountId: AwsAccountId,
         consumerName: ConsumerName
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
       val streamArn = streams.streams.get(streamName).map(_.streamArn)
@@ -163,7 +163,7 @@ class DeregisterStreamConsumerTests
         awsAccountId: AwsAccountId,
         consumerName: ConsumerName
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
       val updated = streams.findAndUpdateStream(streamName) { stream =>
         stream.copy(
@@ -195,7 +195,7 @@ class DeregisterStreamConsumerTests
         awsAccountId: AwsAccountId,
         consumerName: ConsumerName
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
       val updated = streams.findAndUpdateStream(streamName) { stream =>
         stream.copy(

--- a/src/test/scala/kinesis/mock/api/DescribeStreamConsumerTests.scala
+++ b/src/test/scala/kinesis/mock/api/DescribeStreamConsumerTests.scala
@@ -21,7 +21,7 @@ class DescribeStreamConsumerTests
         awsAccountId: AwsAccountId,
         consumerName: ConsumerName
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
       val updated = streams.findAndUpdateStream(streamName) { stream =>
         stream.copy(
@@ -57,7 +57,7 @@ class DescribeStreamConsumerTests
         awsAccountId: AwsAccountId,
         consumerName: ConsumerName
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
       val updated = streams.findAndUpdateStream(streamName) { stream =>
@@ -96,7 +96,7 @@ class DescribeStreamConsumerTests
         awsAccountId: AwsAccountId,
         consumerName: ConsumerName
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
       val streamArn = streams.streams.get(streamName).map(_.streamArn)
@@ -117,7 +117,7 @@ class DescribeStreamConsumerTests
         awsAccountId: AwsAccountId,
         consumerName: ConsumerName
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
       val updated = streams.findAndUpdateStream(streamName) { stream =>
         stream.copy(
@@ -146,7 +146,7 @@ class DescribeStreamConsumerTests
         awsAccountId: AwsAccountId,
         consumerName: ConsumerName
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
       val updated = streams.findAndUpdateStream(streamName) { stream =>
         stream.copy(

--- a/src/test/scala/kinesis/mock/api/DescribeStreamSummaryTests.scala
+++ b/src/test/scala/kinesis/mock/api/DescribeStreamSummaryTests.scala
@@ -18,7 +18,7 @@ class DescribeStreamSummaryTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
       for {

--- a/src/test/scala/kinesis/mock/api/DescribeStreamTests.scala
+++ b/src/test/scala/kinesis/mock/api/DescribeStreamTests.scala
@@ -18,7 +18,7 @@ class DescribeStreamTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
       for {
@@ -42,7 +42,7 @@ class DescribeStreamTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(2, streamName, awsRegion, awsAccountId)
 
       val limit = Some(1)
@@ -70,7 +70,7 @@ class DescribeStreamTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(4, streamName, awsRegion, awsAccountId)
 
       val exclusiveStartShardId = streams.streams

--- a/src/test/scala/kinesis/mock/api/DisableEnhancedMonitoringTests.scala
+++ b/src/test/scala/kinesis/mock/api/DisableEnhancedMonitoringTests.scala
@@ -19,7 +19,7 @@ class DisableEnhancedMonitoringTests
         awsAccountId: AwsAccountId,
         shardLevelMetrics: ShardLevelMetrics
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
       val updated = streams.findAndUpdateStream(streamName)(stream =>

--- a/src/test/scala/kinesis/mock/api/EnableEnhancedMonitoringTests.scala
+++ b/src/test/scala/kinesis/mock/api/EnableEnhancedMonitoringTests.scala
@@ -19,7 +19,7 @@ class EnableEnhancedMonitoringTests
         awsAccountId: AwsAccountId,
         shardLevelMetrics: ShardLevelMetrics
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
       for {

--- a/src/test/scala/kinesis/mock/api/GetRecordsTests.scala
+++ b/src/test/scala/kinesis/mock/api/GetRecordsTests.scala
@@ -22,7 +22,7 @@ class GetRecordsTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
       val shard = streams.streams(streamName).shards.head._1
@@ -75,7 +75,7 @@ class GetRecordsTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
       val shard = streams.streams(streamName).shards.head._1
@@ -128,7 +128,7 @@ class GetRecordsTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
       val shard = streams.streams(streamName).shards.head._1
@@ -197,7 +197,7 @@ class GetRecordsTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
       val shard = streams.streams(streamName).shards.head._1

--- a/src/test/scala/kinesis/mock/api/GetShardIteratorTests.scala
+++ b/src/test/scala/kinesis/mock/api/GetShardIteratorTests.scala
@@ -23,7 +23,7 @@ class GetShardIteratorTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
       val shard = streams.streams(streamName).shards.head._1
@@ -76,7 +76,7 @@ class GetShardIteratorTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
       val shard = streams.streams(streamName).shards.head._1
@@ -129,7 +129,7 @@ class GetShardIteratorTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
       val shard = streams.streams(streamName).shards.head._1
@@ -190,7 +190,7 @@ class GetShardIteratorTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
       val shard = streams.streams(streamName).shards.head._1
@@ -245,7 +245,7 @@ class GetShardIteratorTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
       val shard = streams.streams(streamName).shards.head._1
@@ -299,7 +299,7 @@ class GetShardIteratorTests
           awsRegion: AwsRegion,
           awsAccountId: AwsAccountId
       ) =>
-        val (streams, _) =
+        val streams =
           Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
         val shard = streams.streams(streamName).shards.head._1
@@ -356,7 +356,7 @@ class GetShardIteratorTests
           awsRegion: AwsRegion,
           awsAccountId: AwsAccountId
       ) =>
-        val (streams, _) =
+        val streams =
           Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
         val shard = streams.streams(streamName).shards.head._1
@@ -410,7 +410,7 @@ class GetShardIteratorTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
       val shard = streams.streams(streamName).shards.head._1
@@ -435,7 +435,7 @@ class GetShardIteratorTests
           awsRegion: AwsRegion,
           awsAccountId: AwsAccountId
       ) =>
-        val (streams, _) =
+        val streams =
           Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
         val shard = streams.streams(streamName).shards.head._1
@@ -461,7 +461,7 @@ class GetShardIteratorTests
           awsRegion: AwsRegion,
           awsAccountId: AwsAccountId
       ) =>
-        val (streams, _) =
+        val streams =
           Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
         val shard = streams.streams(streamName).shards.head._1
@@ -487,7 +487,7 @@ class GetShardIteratorTests
           awsRegion: AwsRegion,
           awsAccountId: AwsAccountId
       ) =>
-        val (streams, _) =
+        val streams =
           Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
         val shard = streams.streams(streamName).shards.head._1

--- a/src/test/scala/kinesis/mock/api/IncreaseStreamRetentionPeriodTests.scala
+++ b/src/test/scala/kinesis/mock/api/IncreaseStreamRetentionPeriodTests.scala
@@ -19,7 +19,7 @@ class IncreaseStreamRetentionPeriodTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
       val active = streams.findAndUpdateStream(streamName)(
@@ -48,7 +48,7 @@ class IncreaseStreamRetentionPeriodTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
       val withUpdatedRetention = streams.findAndUpdateStream(streamName)(s =>

--- a/src/test/scala/kinesis/mock/api/ListShardsTests.scala
+++ b/src/test/scala/kinesis/mock/api/ListShardsTests.scala
@@ -21,7 +21,7 @@ class ListShardsTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(100, streamName, awsRegion, awsAccountId)
 
       for {
@@ -44,7 +44,7 @@ class ListShardsTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(100, streamName, awsRegion, awsAccountId)
 
       for {
@@ -99,7 +99,7 @@ class ListShardsTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(100, streamName, awsRegion, awsAccountId)
 
       val exclusiveStartShardId = ShardId.create(10)
@@ -133,7 +133,7 @@ class ListShardsTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(100, streamName, awsRegion, awsAccountId)
 
       val updated = streams.findAndUpdateStream(streamName) { s =>
@@ -184,7 +184,7 @@ class ListShardsTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(100, streamName, awsRegion, awsAccountId)
 
       val updated = streams.findAndUpdateStream(streamName) { s =>
@@ -234,7 +234,7 @@ class ListShardsTests
           awsRegion: AwsRegion,
           awsAccountId: AwsAccountId
       ) =>
-        val (streams, _) =
+        val streams =
           Streams.empty.addStream(100, streamName, awsRegion, awsAccountId)
 
         val updated = streams.findAndUpdateStream(streamName) { s =>
@@ -289,7 +289,7 @@ class ListShardsTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(100, streamName, awsRegion, awsAccountId)
 
       val shardId = streams.streams(streamName).shards.keys.toList(4).shardId
@@ -330,7 +330,7 @@ class ListShardsTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(100, streamName, awsRegion, awsAccountId)
 
       val requestTimestamp = Instant.parse("2021-01-30T00:00:00.00Z")
@@ -401,7 +401,7 @@ class ListShardsTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(100, streamName, awsRegion, awsAccountId)
 
       val requestTimestamp = Instant.parse("2021-01-30T00:00:00.00Z")
@@ -476,7 +476,7 @@ class ListShardsTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(100, streamName, awsRegion, awsAccountId)
 
       for {
@@ -501,7 +501,7 @@ class ListShardsTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(100, streamName, awsRegion, awsAccountId)
 
       for {
@@ -526,7 +526,7 @@ class ListShardsTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(100, streamName, awsRegion, awsAccountId)
 
       for {

--- a/src/test/scala/kinesis/mock/api/ListStreamConsumersTests.scala
+++ b/src/test/scala/kinesis/mock/api/ListStreamConsumersTests.scala
@@ -23,7 +23,7 @@ class ListStreamConsumersTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(100, streamName, awsRegion, awsAccountId)
 
       val consumers = SortedMap.from(
@@ -64,7 +64,7 @@ class ListStreamConsumersTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(100, streamName, awsRegion, awsAccountId)
 
       val streamArn = streams.streams(streamName).streamArn
@@ -86,7 +86,7 @@ class ListStreamConsumersTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(100, streamName, awsRegion, awsAccountId)
 
       val consumers = SortedMap.from(

--- a/src/test/scala/kinesis/mock/api/ListStreamsTests.scala
+++ b/src/test/scala/kinesis/mock/api/ListStreamsTests.scala
@@ -31,7 +31,7 @@ class ListStreamsTests
 
       val streams = streamNames.foldLeft(Streams.empty) {
         case (streams, streamName) =>
-          streams.addStream(1, streamName, awsRegion, awsAccountId)._1
+          streams.addStream(1, streamName, awsRegion, awsAccountId)
       }
 
       for {
@@ -63,7 +63,7 @@ class ListStreamsTests
 
       val streams = streamNames.foldLeft(Streams.empty) {
         case (streams, streamName) =>
-          streams.addStream(1, streamName, awsRegion, awsAccountId)._1
+          streams.addStream(1, streamName, awsRegion, awsAccountId)
       }
 
       val exclusiveStartStreamName = streamNames(3)
@@ -97,7 +97,7 @@ class ListStreamsTests
 
       val streams = streamNames.foldLeft(Streams.empty) {
         case (streams, streamName) =>
-          streams.addStream(1, streamName, awsRegion, awsAccountId)._1
+          streams.addStream(1, streamName, awsRegion, awsAccountId)
       }
 
       for {

--- a/src/test/scala/kinesis/mock/api/ListTagsForStreamTests.scala
+++ b/src/test/scala/kinesis/mock/api/ListTagsForStreamTests.scala
@@ -23,7 +23,7 @@ class ListTagsForStreamTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(100, streamName, awsRegion, awsAccountId)
 
       val withTags =
@@ -47,7 +47,7 @@ class ListTagsForStreamTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(100, streamName, awsRegion, awsAccountId)
 
       val tags: Tags = Gen
@@ -85,7 +85,7 @@ class ListTagsForStreamTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(100, streamName, awsRegion, awsAccountId)
 
       val tags: Tags = Gen

--- a/src/test/scala/kinesis/mock/api/MergeShardsTests.scala
+++ b/src/test/scala/kinesis/mock/api/MergeShardsTests.scala
@@ -2,8 +2,7 @@ package kinesis.mock
 package api
 
 import cats.effect._
-import cats.effect.concurrent.{Ref, Semaphore}
-import cats.syntax.all._
+import cats.effect.concurrent.Ref
 import enumeratum.scalacheck._
 import org.scalacheck.effect.PropF
 
@@ -19,7 +18,7 @@ class MergeShardsTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, shardSemaphoreKeys) =
+      val streams =
         Streams.empty.addStream(5, streamName, awsRegion, awsAccountId)
       val active =
         streams.findAndUpdateStream(streamName)(s =>
@@ -37,14 +36,7 @@ class MergeShardsTests
           shardToMerge.shardId.shardId,
           streamName
         )
-        shardSemaphores <- shardSemaphoreKeys
-          .traverse(k => Semaphore[IO](1).map(s => k -> s))
-          .map(_.toMap)
-        shardSemaphoresRef <- Ref
-          .of[IO, Map[ShardSemaphoresKey, Semaphore[IO]]](
-            shardSemaphores
-          )
-        res <- req.mergeShards(streamsRef, shardSemaphoresRef)
+        res <- req.mergeShards(streamsRef)
         s <- streamsRef.get
       } yield assert(
         res.isRight && s.streams.get(streamName).exists { stream =>
@@ -67,7 +59,7 @@ class MergeShardsTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, shardSemaphoreKeys) =
+      val streams =
         Streams.empty.addStream(5, streamName, awsRegion, awsAccountId)
 
       val shardToMerge =
@@ -84,14 +76,7 @@ class MergeShardsTests
 
       for {
         streamsRef <- Ref.of[IO, Streams](streams)
-        shardSemaphores <- shardSemaphoreKeys
-          .traverse(k => Semaphore[IO](1).map(s => k -> s))
-          .map(_.toMap)
-        shardSemaphoresRef <- Ref
-          .of[IO, Map[ShardSemaphoresKey, Semaphore[IO]]](
-            shardSemaphores
-          )
-        res <- req.mergeShards(streamsRef, shardSemaphoresRef)
+        res <- req.mergeShards(streamsRef)
       } yield assert(
         res.isLeft,
         s"req: $req\nres: $res"
@@ -104,7 +89,7 @@ class MergeShardsTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, shardSemaphoreKeys) =
+      val streams =
         Streams.empty.addStream(5, streamName, awsRegion, awsAccountId)
       val active = streams.findAndUpdateStream(streamName)(s =>
         s.copy(streamStatus = StreamStatus.ACTIVE)
@@ -131,14 +116,7 @@ class MergeShardsTests
 
       for {
         streamsRef <- Ref.of[IO, Streams](active)
-        shardSemaphores <- shardSemaphoreKeys
-          .traverse(k => Semaphore[IO](1).map(s => k -> s))
-          .map(_.toMap)
-        shardSemaphoresRef <- Ref
-          .of[IO, Map[ShardSemaphoresKey, Semaphore[IO]]](
-            shardSemaphores
-          )
-        res <- req.mergeShards(streamsRef, shardSemaphoresRef)
+        res <- req.mergeShards(streamsRef)
       } yield assert(
         res.isLeft,
         s"req: $req\nres: $res"
@@ -151,7 +129,7 @@ class MergeShardsTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, shardSemaphoreKeys) =
+      val streams =
         Streams.empty.addStream(5, streamName, awsRegion, awsAccountId)
       val active = streams.findAndUpdateStream(streamName)(s =>
         s.copy(streamStatus = StreamStatus.ACTIVE)
@@ -178,14 +156,7 @@ class MergeShardsTests
 
       for {
         streamsRef <- Ref.of[IO, Streams](active)
-        shardSemaphores <- shardSemaphoreKeys
-          .traverse(k => Semaphore[IO](1).map(s => k -> s))
-          .map(_.toMap)
-        shardSemaphoresRef <- Ref
-          .of[IO, Map[ShardSemaphoresKey, Semaphore[IO]]](
-            shardSemaphores
-          )
-        res <- req.mergeShards(streamsRef, shardSemaphoresRef)
+        res <- req.mergeShards(streamsRef)
       } yield assert(
         res.isLeft,
         s"req: $req\nres: $res"
@@ -198,7 +169,7 @@ class MergeShardsTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, shardSemaphoreKeys) =
+      val streams =
         Streams.empty.addStream(5, streamName, awsRegion, awsAccountId)
       val active = streams.findAndUpdateStream(streamName)(s =>
         s.copy(streamStatus = StreamStatus.ACTIVE)
@@ -217,14 +188,7 @@ class MergeShardsTests
 
       for {
         streamsRef <- Ref.of[IO, Streams](active)
-        shardSemaphores <- shardSemaphoreKeys
-          .traverse(k => Semaphore[IO](1).map(s => k -> s))
-          .map(_.toMap)
-        shardSemaphoresRef <- Ref
-          .of[IO, Map[ShardSemaphoresKey, Semaphore[IO]]](
-            shardSemaphores
-          )
-        res <- req.mergeShards(streamsRef, shardSemaphoresRef)
+        res <- req.mergeShards(streamsRef)
       } yield assert(
         res.isLeft,
         s"req: $req\nres: $res"

--- a/src/test/scala/kinesis/mock/api/PutRecordTests.scala
+++ b/src/test/scala/kinesis/mock/api/PutRecordTests.scala
@@ -2,8 +2,7 @@ package kinesis.mock
 package api
 
 import cats.effect._
-import cats.effect.concurrent.{Ref, Semaphore}
-import cats.syntax.all._
+import cats.effect.concurrent.Ref
 import enumeratum.scalacheck._
 import org.scalacheck.effect.PropF
 
@@ -20,7 +19,7 @@ class PutRecordTests
         awsAccountId: AwsAccountId,
         initReq: PutRecordRequest
     ) =>
-      val (streams, shardSemaphoreKeys) =
+      val streams =
         Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
       val active =
         streams.findAndUpdateStream(streamName)(s =>
@@ -33,14 +32,7 @@ class PutRecordTests
 
       for {
         streamsRef <- Ref.of[IO, Streams](active)
-        shardSemaphores <- shardSemaphoreKeys
-          .traverse(k => Semaphore[IO](1).map(s => k -> s))
-          .map(_.toMap)
-        shardSemaphoresRef <- Ref
-          .of[IO, Map[ShardSemaphoresKey, Semaphore[IO]]](
-            shardSemaphores
-          )
-        res <- req.putRecord(streamsRef, shardSemaphoresRef)
+        res <- req.putRecord(streamsRef)
         s <- streamsRef.get
       } yield assert(
         res.isRight && s.streams.get(streamName).exists { stream =>
@@ -60,7 +52,7 @@ class PutRecordTests
           awsAccountId: AwsAccountId,
           initReq: PutRecordRequest
       ) =>
-        val (streams, shardSemaphoreKeys) =
+        val streams =
           Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
         val req = initReq.copy(
@@ -69,14 +61,7 @@ class PutRecordTests
 
         for {
           streamsRef <- Ref.of[IO, Streams](streams)
-          shardSemaphores <- shardSemaphoreKeys
-            .traverse(k => Semaphore[IO](1).map(s => k -> s))
-            .map(_.toMap)
-          shardSemaphoresRef <- Ref
-            .of[IO, Map[ShardSemaphoresKey, Semaphore[IO]]](
-              shardSemaphores
-            )
-          res <- req.putRecord(streamsRef, shardSemaphoresRef)
+          res <- req.putRecord(streamsRef)
         } yield assert(res.isLeft, s"req: $req\nres: $res")
     }
   )
@@ -89,7 +74,7 @@ class PutRecordTests
           awsAccountId: AwsAccountId,
           initReq: PutRecordRequest
       ) =>
-        val (streams, shardSemaphoreKeys) =
+        val streams =
           Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
         val updated = streams.findAndUpdateStream(streamName)(s =>
@@ -108,14 +93,7 @@ class PutRecordTests
 
         for {
           streamsRef <- Ref.of[IO, Streams](updated)
-          shardSemaphores <- shardSemaphoreKeys
-            .traverse(k => Semaphore[IO](1).map(s => k -> s))
-            .map(_.toMap)
-          shardSemaphoresRef <- Ref
-            .of[IO, Map[ShardSemaphoresKey, Semaphore[IO]]](
-              shardSemaphores
-            )
-          res <- req.putRecord(streamsRef, shardSemaphoresRef)
+          res <- req.putRecord(streamsRef)
         } yield assert(res.isLeft, s"req: $req\nres: $res")
     }
   )

--- a/src/test/scala/kinesis/mock/api/RegisterStreamConsumerTests.scala
+++ b/src/test/scala/kinesis/mock/api/RegisterStreamConsumerTests.scala
@@ -23,7 +23,7 @@ class RegisterStreamConsumerTests
         awsAccountId: AwsAccountId,
         consumerName: ConsumerName
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
       val streamArn = streams.streams(streamName).streamArn
@@ -48,7 +48,7 @@ class RegisterStreamConsumerTests
         awsAccountId: AwsAccountId,
         consumerName: ConsumerName
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
       val consumers = SortedMap.from(
@@ -84,7 +84,7 @@ class RegisterStreamConsumerTests
           awsAccountId: AwsAccountId,
           consumerName: ConsumerName
       ) =>
-        val (streams, _) =
+        val streams =
           Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
         val consumers = SortedMap.from(

--- a/src/test/scala/kinesis/mock/api/RemoveTagsFromStreamTests.scala
+++ b/src/test/scala/kinesis/mock/api/RemoveTagsFromStreamTests.scala
@@ -22,7 +22,7 @@ class RemoveTagsFromStreamTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
       val tags: Tags = Gen

--- a/src/test/scala/kinesis/mock/api/StartStreamEncryptionTests.scala
+++ b/src/test/scala/kinesis/mock/api/StartStreamEncryptionTests.scala
@@ -18,7 +18,7 @@ class StartStreamEncryptionTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
       val asActive = streams.findAndUpdateStream(streamName)(x =>
@@ -55,7 +55,7 @@ class StartStreamEncryptionTests
           awsRegion: AwsRegion,
           awsAccountId: AwsAccountId
       ) =>
-        val (streams, _) =
+        val streams =
           Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
         val asActive = streams.findAndUpdateStream(streamName)(x =>
@@ -85,7 +85,7 @@ class StartStreamEncryptionTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
       val keyId = keyIdGen.one

--- a/src/test/scala/kinesis/mock/api/StopStreamEncryptionTests.scala
+++ b/src/test/scala/kinesis/mock/api/StopStreamEncryptionTests.scala
@@ -18,7 +18,7 @@ class StopStreamEncryptionTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
       val asActive = streams.findAndUpdateStream(streamName)(x =>
@@ -51,7 +51,7 @@ class StopStreamEncryptionTests
           awsRegion: AwsRegion,
           awsAccountId: AwsAccountId
       ) =>
-        val (streams, _) =
+        val streams =
           Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
         val asActive = streams.findAndUpdateStream(streamName)(x =>
@@ -81,7 +81,7 @@ class StopStreamEncryptionTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, _) =
+      val streams =
         Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
       val keyId = keyIdGen.one

--- a/src/test/scala/kinesis/mock/api/UpdateShardCountTests.scala
+++ b/src/test/scala/kinesis/mock/api/UpdateShardCountTests.scala
@@ -2,8 +2,7 @@ package kinesis.mock
 package api
 
 import cats.effect._
-import cats.effect.concurrent.{Ref, Semaphore}
-import cats.syntax.all._
+import cats.effect.concurrent.Ref
 import enumeratum.scalacheck._
 import org.scalacheck.effect.PropF
 
@@ -19,7 +18,7 @@ class UpdateShardCountTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, shardSemaphoreKeys) =
+      val streams =
         Streams.empty.addStream(5, streamName, awsRegion, awsAccountId)
       val active =
         streams.findAndUpdateStream(streamName)(s =>
@@ -35,14 +34,7 @@ class UpdateShardCountTests
 
       for {
         streamsRef <- Ref.of[IO, Streams](active)
-        shardSemaphores <- shardSemaphoreKeys
-          .traverse(k => Semaphore[IO](1).map(s => k -> s))
-          .map(_.toMap)
-        shardSemaphoresRef <- Ref
-          .of[IO, Map[ShardSemaphoresKey, Semaphore[IO]]](
-            shardSemaphores
-          )
-        res <- req.updateShardCount(streamsRef, shardSemaphoresRef, 50)
+        res <- req.updateShardCount(streamsRef, 50)
         s <- streamsRef.get
       } yield assert(
         res.isRight && s.streams.get(streamName).exists { stream =>
@@ -69,7 +61,7 @@ class UpdateShardCountTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, shardSemaphoreKeys) =
+      val streams =
         Streams.empty.addStream(10, streamName, awsRegion, awsAccountId)
       val active =
         streams.findAndUpdateStream(streamName)(s =>
@@ -85,14 +77,7 @@ class UpdateShardCountTests
 
       for {
         streamsRef <- Ref.of[IO, Streams](active)
-        shardSemaphores <- shardSemaphoreKeys
-          .traverse(k => Semaphore[IO](1).map(s => k -> s))
-          .map(_.toMap)
-        shardSemaphoresRef <- Ref
-          .of[IO, Map[ShardSemaphoresKey, Semaphore[IO]]](
-            shardSemaphores
-          )
-        res <- req.updateShardCount(streamsRef, shardSemaphoresRef, 50)
+        res <- req.updateShardCount(streamsRef, 50)
         s <- streamsRef.get
       } yield assert(
         res.isRight && s.streams.get(streamName).exists { stream =>
@@ -120,7 +105,7 @@ class UpdateShardCountTests
           awsRegion: AwsRegion,
           awsAccountId: AwsAccountId
       ) =>
-        val (streams, shardSemaphoreKeys) =
+        val streams =
           Streams.empty.addStream(5, streamName, awsRegion, awsAccountId)
         val active =
           streams.findAndUpdateStream(streamName)(s =>
@@ -136,14 +121,7 @@ class UpdateShardCountTests
 
         for {
           streamsRef <- Ref.of[IO, Streams](active)
-          shardSemaphores <- shardSemaphoreKeys
-            .traverse(k => Semaphore[IO](1).map(s => k -> s))
-            .map(_.toMap)
-          shardSemaphoresRef <- Ref
-            .of[IO, Map[ShardSemaphoresKey, Semaphore[IO]]](
-              shardSemaphores
-            )
-          res <- req.updateShardCount(streamsRef, shardSemaphoresRef, 50)
+          res <- req.updateShardCount(streamsRef, 50)
         } yield assert(res.isLeft, s"req: $req\nres: $res")
     }
   )
@@ -155,7 +133,7 @@ class UpdateShardCountTests
           awsRegion: AwsRegion,
           awsAccountId: AwsAccountId
       ) =>
-        val (streams, shardSemaphoreKeys) =
+        val streams =
           Streams.empty.addStream(10, streamName, awsRegion, awsAccountId)
         val active =
           streams.findAndUpdateStream(streamName)(s =>
@@ -171,14 +149,7 @@ class UpdateShardCountTests
 
         for {
           streamsRef <- Ref.of[IO, Streams](active)
-          shardSemaphores <- shardSemaphoreKeys
-            .traverse(k => Semaphore[IO](1).map(s => k -> s))
-            .map(_.toMap)
-          shardSemaphoresRef <- Ref
-            .of[IO, Map[ShardSemaphoresKey, Semaphore[IO]]](
-              shardSemaphores
-            )
-          res <- req.updateShardCount(streamsRef, shardSemaphoresRef, 50)
+          res <- req.updateShardCount(streamsRef, 50)
         } yield assert(res.isLeft, s"req: $req\nres: $res")
     }
   )
@@ -189,7 +160,7 @@ class UpdateShardCountTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, shardSemaphoreKeys) =
+      val streams =
         Streams.empty.addStream(5, streamName, awsRegion, awsAccountId)
       val active =
         streams.findAndUpdateStream(streamName)(s =>
@@ -205,14 +176,7 @@ class UpdateShardCountTests
 
       for {
         streamsRef <- Ref.of[IO, Streams](active)
-        shardSemaphores <- shardSemaphoreKeys
-          .traverse(k => Semaphore[IO](1).map(s => k -> s))
-          .map(_.toMap)
-        shardSemaphoresRef <- Ref
-          .of[IO, Map[ShardSemaphoresKey, Semaphore[IO]]](
-            shardSemaphores
-          )
-        res <- req.updateShardCount(streamsRef, shardSemaphoresRef, 9)
+        res <- req.updateShardCount(streamsRef, 9)
       } yield assert(res.isLeft, s"req: $req\nres: $res")
   })
 
@@ -222,7 +186,7 @@ class UpdateShardCountTests
         awsRegion: AwsRegion,
         awsAccountId: AwsAccountId
     ) =>
-      val (streams, shardSemaphoreKeys) =
+      val streams =
         Streams.empty.addStream(5, streamName, awsRegion, awsAccountId)
 
       val req =
@@ -234,14 +198,7 @@ class UpdateShardCountTests
 
       for {
         streamsRef <- Ref.of[IO, Streams](streams)
-        shardSemaphores <- shardSemaphoreKeys
-          .traverse(k => Semaphore[IO](1).map(s => k -> s))
-          .map(_.toMap)
-        shardSemaphoresRef <- Ref
-          .of[IO, Map[ShardSemaphoresKey, Semaphore[IO]]](
-            shardSemaphores
-          )
-        res <- req.updateShardCount(streamsRef, shardSemaphoresRef, 50)
+        res <- req.updateShardCount(streamsRef, 50)
       } yield assert(res.isLeft, s"req: $req\nres: $res")
   })
 }


### PR DESCRIPTION
## Changes Introduced

Having Semaphores around the shards was not necessary as using `Ref.update` is atomic on its own. This just introduced more performance overhead.

## Applicable linked issues

N/A

## Checklist (check all that apply)

- [X] This change maintains backwards compatibility
- [ ] I have introduced tests for all new features and changes
- [ ] I have added documentation covering all new features and changes
- [X] This pull-request is ready for review