### PR TITLE
More performant collections

### DIFF
--- a/src/fun/scala/kinesis/mock/AddTagsToStreamTests.scala
+++ b/src/fun/scala/kinesis/mock/AddTagsToStreamTests.scala
@@ -1,6 +1,5 @@
 package kinesis.mock
 
-import scala.collection.SortedMap
 import scala.jdk.CollectionConverters._
 
 import cats.effect.IO
@@ -28,7 +27,7 @@ class AddTagsToStreamTests
         .toIO
       res <- listTagsForStream(resources)
     } yield assert(
-      SortedMap.from(
+      Map.from(
         res.tags().asScala.map(tag => tag.key() -> tag.value())
       ) == tags.tags,
       res

--- a/src/fun/scala/kinesis/mock/AwsFunctionalTests.scala
+++ b/src/fun/scala/kinesis/mock/AwsFunctionalTests.scala
@@ -24,7 +24,7 @@ trait AwsFunctionalTests extends CatsEffectFunFixtures { _: CatsEffectSuite =>
   protected val genStreamShardCount = 3
 
   // this must match env var INITIALIZE_STREAMS in docker-compose.yml
-  protected val initializedStreams = List(
+  protected val initializedStreams = Vector(
     "stream1" -> 3,
     "stream2" -> 2,
     "stream3" -> 1,

--- a/src/fun/scala/kinesis/mock/GetRecordsTests.scala
+++ b/src/fun/scala/kinesis/mock/GetRecordsTests.scala
@@ -19,7 +19,7 @@ class GetRecordsTests extends munit.CatsEffectSuite with AwsFunctionalTests {
       recordRequests <- IO(
         putRecordRequestArb.arbitrary
           .take(5)
-          .toList
+          .toVector
           .map(_.copy(streamName = resources.streamName))
           .map(x =>
             PutRecordRequest
@@ -45,7 +45,7 @@ class GetRecordsTests extends munit.CatsEffectSuite with AwsFunctionalTests {
             .build()
         )
         .toIO
-        .map(_.shards().asScala.toList)
+        .map(_.shards().asScala.toVector)
       shardIterators <- shards.traverse(shard =>
         resources.kinesisClient
           .getShardIterator(
@@ -66,7 +66,7 @@ class GetRecordsTests extends munit.CatsEffectSuite with AwsFunctionalTests {
           )
           .toIO
       )
-      res = gets.flatMap(_.records().asScala.toList)
+      res = gets.flatMap(_.records().asScala.toVector)
     } yield assert(
       res.length == 5 && res.forall(rec =>
         recordRequests.exists(req =>

--- a/src/fun/scala/kinesis/mock/KCLRecordProcessor.scala
+++ b/src/fun/scala/kinesis/mock/KCLRecordProcessor.scala
@@ -17,7 +17,7 @@ case class KCLRecordProcessor(
   override def processRecords(x: ProcessRecordsInput): Unit = x
     .records()
     .asScala
-    .toList
+    .toVector
     .traverse_(record =>
       resultsQueue.enqueue1(record) *> IO(
         x.checkpointer()

--- a/src/fun/scala/kinesis/mock/KCLTests.scala
+++ b/src/fun/scala/kinesis/mock/KCLTests.scala
@@ -119,7 +119,7 @@ class KCLTests extends munit.CatsEffectSuite with AwsFunctionalTests {
         .records(
           putRecordsRequestEntryArb.arbitrary
             .take(5)
-            .toList
+            .toVector
             .map(x =>
               PutRecordsRequestEntry
                 .builder()
@@ -144,11 +144,11 @@ class KCLTests extends munit.CatsEffectSuite with AwsFunctionalTests {
     )(
       resources.resultsQueue.getSize.map(_ == 5)
     )
-    resRecords <- resources.resultsQueue.dequeueChunk1(5).map(_.toList)
+    resRecords <- resources.resultsQueue.dequeueChunk1(5).map(_.toVector)
   } yield assert(
     gotAllRecords && resRecords
       .map(_.partitionKey())
-      .diff(req.records().asScala.toList.map(_.partitionKey()))
+      .diff(req.records().asScala.toVector.map(_.partitionKey()))
       .isEmpty,
     s"Got All Records: $gotAllRecords\nLength: ${resRecords.length}"
   )

--- a/src/fun/scala/kinesis/mock/KPLTests.scala
+++ b/src/fun/scala/kinesis/mock/KPLTests.scala
@@ -40,8 +40,8 @@ class KPLTests extends munit.CatsEffectSuite with AwsFunctionalTests {
 
   kplFixture.test("it should produce records") { resources =>
     for {
-      dataRecords <- IO(dataGen.take(20).toList)
-      res <- dataRecords.traverse(data =>
+      dataRecords <- IO(dataGen.take(20).toVector)
+      res <- dataRecords.parTraverse(data =>
         resources.kpl
           .addUserRecord(
             new UserRecord(

--- a/src/fun/scala/kinesis/mock/ListStreamConsumersTests.scala
+++ b/src/fun/scala/kinesis/mock/ListStreamConsumersTests.scala
@@ -16,7 +16,7 @@ class ListStreamConsumersTests
 
   fixture.test("It should list stream consumers") { resources =>
     for {
-      consumerNames <- IO(consumerNameGen.take(3).toList.map(_.consumerName))
+      consumerNames <- IO(consumerNameGen.take(3).toVector.map(_.consumerName))
       streamSummary <- describeStreamSummary(resources)
       streamArn = streamSummary.streamDescriptionSummary().streamARN()
       registerRes <- consumerNames.traverse(consumerName =>
@@ -39,7 +39,7 @@ class ListStreamConsumersTests
       res
         .consumers()
         .asScala
-        .toList
+        .toVector
         .sortBy(_.consumerName())
         .map(x =>
           models.ConsumerSummary(

--- a/src/fun/scala/kinesis/mock/ListTagsForStreamTests.scala
+++ b/src/fun/scala/kinesis/mock/ListTagsForStreamTests.scala
@@ -1,6 +1,5 @@
 package kinesis.mock
 
-import scala.collection.SortedMap
 import scala.jdk.CollectionConverters._
 
 import cats.effect.IO
@@ -28,7 +27,7 @@ class ListTagsForStreamTests
         .toIO
       res <- listTagsForStream(resources)
     } yield assert(
-      SortedMap.from(
+      Map.from(
         res.tags().asScala.map(tag => tag.key() -> tag.value())
       ) == tags.tags,
       res

--- a/src/fun/scala/kinesis/mock/MergeShardsTests.scala
+++ b/src/fun/scala/kinesis/mock/MergeShardsTests.scala
@@ -34,7 +34,7 @@ class MergeShardsTests extends munit.CatsEffectSuite with AwsFunctionalTests {
         )
         .toIO
         .map(
-          _.shards().asScala.toList.filter(
+          _.shards().asScala.toVector.filter(
             _.sequenceNumberRange()
               .endingSequenceNumber() == null // scalafix:ok
           )
@@ -59,7 +59,7 @@ class MergeShardsTests extends munit.CatsEffectSuite with AwsFunctionalTests {
         )
         .toIO
         .map(
-          _.shards().asScala.toList.filter(
+          _.shards().asScala.toVector.filter(
             _.sequenceNumberRange()
               .endingSequenceNumber() == null // scalafix:ok
           )

--- a/src/fun/scala/kinesis/mock/PutRecordTests.scala
+++ b/src/fun/scala/kinesis/mock/PutRecordTests.scala
@@ -19,7 +19,7 @@ class PutRecordTests extends munit.CatsEffectSuite with AwsFunctionalTests {
       recordRequests <- IO(
         putRecordRequestArb.arbitrary
           .take(5)
-          .toList
+          .toVector
           .map(_.copy(streamName = resources.streamName))
           .map(x =>
             PutRecordRequest
@@ -45,7 +45,7 @@ class PutRecordTests extends munit.CatsEffectSuite with AwsFunctionalTests {
             .build()
         )
         .toIO
-        .map(_.shards().asScala.toList)
+        .map(_.shards().asScala.toVector)
       shardIterators <- shards.traverse(shard =>
         resources.kinesisClient
           .getShardIterator(
@@ -66,7 +66,7 @@ class PutRecordTests extends munit.CatsEffectSuite with AwsFunctionalTests {
           )
           .toIO
       )
-      res = gets.flatMap(_.records().asScala.toList)
+      res = gets.flatMap(_.records().asScala.toVector)
     } yield assert(
       res.length == 5 && res.forall(rec =>
         recordRequests.exists(req =>

--- a/src/fun/scala/kinesis/mock/PutRecordsTests.scala
+++ b/src/fun/scala/kinesis/mock/PutRecordsTests.scala
@@ -22,7 +22,7 @@ class PutRecordsTests extends munit.CatsEffectSuite with AwsFunctionalTests {
           .records(
             putRecordsRequestEntryArb.arbitrary
               .take(5)
-              .toList
+              .toVector
               .map(x =>
                 PutRecordsRequestEntry
                   .builder()
@@ -45,7 +45,7 @@ class PutRecordsTests extends munit.CatsEffectSuite with AwsFunctionalTests {
             .build()
         )
         .toIO
-        .map(_.shards().asScala.toList)
+        .map(_.shards().asScala.toVector)
       shardIterators <- shards.traverse(shard =>
         resources.kinesisClient
           .getShardIterator(
@@ -66,10 +66,10 @@ class PutRecordsTests extends munit.CatsEffectSuite with AwsFunctionalTests {
           )
           .toIO
       )
-      res = gets.flatMap(_.records().asScala.toList)
+      res = gets.flatMap(_.records().asScala.toVector)
     } yield assert(
       res.length == 5 && res.forall(rec =>
-        req.records.asScala.toList.exists(req =>
+        req.records.asScala.toVector.exists(req =>
           req.data.asByteArray.sameElements(rec.data.asByteArray)
             && req.partitionKey == rec.partitionKey
         )

--- a/src/fun/scala/kinesis/mock/SplitShardTests.scala
+++ b/src/fun/scala/kinesis/mock/SplitShardTests.scala
@@ -44,7 +44,7 @@ class SplitShardTests extends munit.CatsEffectSuite with AwsFunctionalTests {
         )
         .toIO
         .map(
-          _.shards().asScala.toList.filter(
+          _.shards().asScala.toVector.filter(
             _.sequenceNumberRange()
               .endingSequenceNumber() == null // scalafix:ok
           )

--- a/src/fun/scala/kinesis/mock/UpdateShardCountTests.scala
+++ b/src/fun/scala/kinesis/mock/UpdateShardCountTests.scala
@@ -36,7 +36,7 @@ class UpdateShardCountTests
         )
         .toIO
         .map(
-          _.shards().asScala.toList.filter(
+          _.shards().asScala.toVector.filter(
             _.sequenceNumberRange()
               .endingSequenceNumber() == null // scalafix:ok
           )

--- a/src/fun/scala/kinesis/mock/syntax/javaFuture.scala
+++ b/src/fun/scala/kinesis/mock/syntax/javaFuture.scala
@@ -20,7 +20,7 @@ trait JavaFutureSyntax {
   ): JavaFutureSyntax.JavaFutureOps[A] =
     new JavaFutureSyntax.JavaFutureOps(future)
 
-  implicit def toVectorenableFutureOps[A](
+  implicit def toListenableFutureOps[A](
       future: => ListenableFuture[A]
   ): JavaFutureSyntax.ListenableFutureOps[A] =
     new JavaFutureSyntax.ListenableFutureOps(future)

--- a/src/fun/scala/kinesis/mock/syntax/javaFuture.scala
+++ b/src/fun/scala/kinesis/mock/syntax/javaFuture.scala
@@ -20,7 +20,7 @@ trait JavaFutureSyntax {
   ): JavaFutureSyntax.JavaFutureOps[A] =
     new JavaFutureSyntax.JavaFutureOps(future)
 
-  implicit def toListenableFutureOps[A](
+  implicit def toVectorenableFutureOps[A](
       future: => ListenableFuture[A]
   ): JavaFutureSyntax.ListenableFutureOps[A] =
     new JavaFutureSyntax.ListenableFutureOps(future)

--- a/src/main/scala/kinesis/mock/KinesisMockService.scala
+++ b/src/main/scala/kinesis/mock/KinesisMockService.scala
@@ -42,7 +42,7 @@ object KinesisMockService extends IOApp {
           cacheConfig.createStreamDuration,
           context,
           logger,
-          cacheConfig.initializeStreams.toList.flatten
+          cacheConfig.initializeStreams.toVector.flatten
         )
         serviceConfig <- KinesisMockServiceConfig.read(blocker)
         app = new KinesisMockRoutes(cache).routes.orNotFound
@@ -92,7 +92,7 @@ object KinesisMockService extends IOApp {
       createStreamDuration: FiniteDuration,
       context: LoggingContext,
       logger: SelfAwareStructuredLogger[IO],
-      streams: List[CreateStreamRequest]
+      streams: Vector[CreateStreamRequest]
   ): IO[Unit] = {
     def isInitStreamDone(streamName: StreamName): IO[Boolean] = {
       val descReq = DescribeStreamSummaryRequest(streamName)

--- a/src/main/scala/kinesis/mock/api/CreateStreamRequest.scala
+++ b/src/main/scala/kinesis/mock/api/CreateStreamRequest.scala
@@ -42,7 +42,7 @@ final case class CreateStreamRequest(shardCount: Int, streamName: StreamName) {
         for {
           res <- streamsRef
             .update(x =>
-              x.copy(streams = x.streams ++ List(streamName -> newStream))
+              x.copy(streams = x.streams ++ Vector(streamName -> newStream))
             )
         } yield res
       }

--- a/src/main/scala/kinesis/mock/api/CreateStreamRequest.scala
+++ b/src/main/scala/kinesis/mock/api/CreateStreamRequest.scala
@@ -42,7 +42,7 @@ final case class CreateStreamRequest(shardCount: Int, streamName: StreamName) {
         for {
           res <- streamsRef
             .update(x =>
-              x.copy(streams = x.streams ++ Vector(streamName -> newStream))
+              x.copy(streams = x.streams + (streamName -> newStream))
             )
         } yield res
       }

--- a/src/main/scala/kinesis/mock/api/DeleteStreamRequest.scala
+++ b/src/main/scala/kinesis/mock/api/DeleteStreamRequest.scala
@@ -1,8 +1,6 @@
 package kinesis.mock
 package api
 
-import scala.collection.SortedMap
-
 import cats.Eq
 import cats.effect.IO
 import cats.effect.concurrent.Ref
@@ -40,13 +38,13 @@ final case class DeleteStreamRequest(
             )
         )
         .traverse { stream =>
-          val deletingStream = SortedMap(
+          val deletingStream = Map(
             streamName -> stream.copy(
-              shards = SortedMap.empty,
+              shards = Map.empty,
               streamStatus = StreamStatus.DELETING,
               tags = Tags.empty,
-              enhancedMonitoring = List.empty,
-              consumers = SortedMap.empty
+              enhancedMonitoring = Vector.empty,
+              consumers = Map.empty
             )
           )
 

--- a/src/main/scala/kinesis/mock/api/DeregisterStreamConsumerRequest.scala
+++ b/src/main/scala/kinesis/mock/api/DeregisterStreamConsumerRequest.scala
@@ -27,7 +27,7 @@ final case class DeregisterStreamConsumerRequest(
       .update(x =>
         x.updateStream(
           stream.copy(consumers =
-            stream.consumers ++ Vector(consumer.consumerName -> newConsumer)
+            stream.consumers + (consumer.consumerName -> newConsumer)
           )
         )
       )

--- a/src/main/scala/kinesis/mock/api/DeregisterStreamConsumerRequest.scala
+++ b/src/main/scala/kinesis/mock/api/DeregisterStreamConsumerRequest.scala
@@ -27,7 +27,7 @@ final case class DeregisterStreamConsumerRequest(
       .update(x =>
         x.updateStream(
           stream.copy(consumers =
-            stream.consumers ++ List(consumer.consumerName -> newConsumer)
+            stream.consumers ++ Vector(consumer.consumerName -> newConsumer)
           )
         )
       )

--- a/src/main/scala/kinesis/mock/api/DisableEnhancedMonitoringRequest.scala
+++ b/src/main/scala/kinesis/mock/api/DisableEnhancedMonitoringRequest.scala
@@ -12,7 +12,7 @@ import kinesis.mock.validations.CommonValidations
 
 // https://docs.aws.amazon.com/kinesis/latest/APIReference/API_DisableEnhancedMonitoring.html
 final case class DisableEnhancedMonitoringRequest(
-    shardLevelMetrics: List[ShardLevelMetric],
+    shardLevelMetrics: Vector[ShardLevelMetric],
     streamName: StreamName
 ) {
   def disableEnhancedMonitoring(
@@ -27,14 +27,14 @@ final case class DisableEnhancedMonitoringRequest(
             stream.enhancedMonitoring.flatMap(_.shardLevelMetrics)
           val desired =
             if (shardLevelMetrics.contains(ShardLevelMetric.ALL))
-              List.empty
+              Vector.empty
             else current.diff(shardLevelMetrics)
 
           streamsRef
             .update(x =>
               x.updateStream(
                 stream
-                  .copy(enhancedMonitoring = List(ShardLevelMetrics(desired)))
+                  .copy(enhancedMonitoring = Vector(ShardLevelMetrics(desired)))
               )
             )
             .as(
@@ -59,7 +59,7 @@ object DisableEnhancedMonitoringRequest {
     for {
       shardLevelMetrics <- x
         .downField("ShardLevelMetrics")
-        .as[List[ShardLevelMetric]]
+        .as[Vector[ShardLevelMetric]]
       streamName <- x.downField("StreamName").as[StreamName]
     } yield DisableEnhancedMonitoringRequest(shardLevelMetrics, streamName)
   }

--- a/src/main/scala/kinesis/mock/api/DisableEnhancedMonitoringResponse.scala
+++ b/src/main/scala/kinesis/mock/api/DisableEnhancedMonitoringResponse.scala
@@ -7,8 +7,8 @@ import io.circe
 import kinesis.mock.models._
 
 final case class DisableEnhancedMonitoringResponse(
-    currentShardLevelMetrics: List[ShardLevelMetric],
-    desiredShardLevelMetrics: List[ShardLevelMetric],
+    currentShardLevelMetrics: Vector[ShardLevelMetric],
+    desiredShardLevelMetrics: Vector[ShardLevelMetric],
     streamName: StreamName
 )
 
@@ -28,10 +28,10 @@ object DisableEnhancedMonitoringResponse {
     for {
       currentShardLevelMetrics <- x
         .downField("CurrentShardLevelMetrics")
-        .as[List[ShardLevelMetric]]
+        .as[Vector[ShardLevelMetric]]
       desiredShardLevelMetrics <- x
         .downField("DesiredShardLevelMetrics")
-        .as[List[ShardLevelMetric]]
+        .as[Vector[ShardLevelMetric]]
       streamName <- x.downField("StreamName").as[StreamName]
     } yield DisableEnhancedMonitoringResponse(
       currentShardLevelMetrics,

--- a/src/main/scala/kinesis/mock/api/EnableEnhancedMonitoringRequest.scala
+++ b/src/main/scala/kinesis/mock/api/EnableEnhancedMonitoringRequest.scala
@@ -12,7 +12,7 @@ import kinesis.mock.validations.CommonValidations
 
 // https://docs.aws.amazon.com/kinesis/latest/APIReference/API_EnableEnhancedMonitoring.html
 final case class EnableEnhancedMonitoringRequest(
-    shardLevelMetrics: List[ShardLevelMetric],
+    shardLevelMetrics: Vector[ShardLevelMetric],
     streamName: StreamName
 ) {
   def enableEnhancedMonitoring(
@@ -28,14 +28,14 @@ final case class EnableEnhancedMonitoringRequest(
             if (shardLevelMetrics.contains(ShardLevelMetric.ALL))
               ShardLevelMetric.values
                 .filterNot(_ == ShardLevelMetric.ALL)
-                .toList
+                .toVector
             else (current ++ shardLevelMetrics).distinct
 
           streamsRef
             .update(x =>
               x.updateStream(
                 stream
-                  .copy(enhancedMonitoring = List(ShardLevelMetrics(desired)))
+                  .copy(enhancedMonitoring = Vector(ShardLevelMetrics(desired)))
               )
             )
             .as(
@@ -60,7 +60,7 @@ object EnableEnhancedMonitoringRequest {
     for {
       shardLevelMetrics <- x
         .downField("ShardLevelMetrics")
-        .as[List[ShardLevelMetric]]
+        .as[Vector[ShardLevelMetric]]
       streamName <- x.downField("StreamName").as[StreamName]
     } yield EnableEnhancedMonitoringRequest(shardLevelMetrics, streamName)
   }

--- a/src/main/scala/kinesis/mock/api/EnableEnhancedMonitoringResponse.scala
+++ b/src/main/scala/kinesis/mock/api/EnableEnhancedMonitoringResponse.scala
@@ -7,8 +7,8 @@ import io.circe
 import kinesis.mock.models._
 
 final case class EnableEnhancedMonitoringResponse(
-    currentShardLevelMetrics: List[ShardLevelMetric],
-    desiredShardLevelMetrics: List[ShardLevelMetric],
+    currentShardLevelMetrics: Vector[ShardLevelMetric],
+    desiredShardLevelMetrics: Vector[ShardLevelMetric],
     streamName: StreamName
 )
 
@@ -28,10 +28,10 @@ object EnableEnhancedMonitoringResponse {
     for {
       currentShardLevelMetrics <- x
         .downField("CurrentShardLevelMetrics")
-        .as[List[ShardLevelMetric]]
+        .as[Vector[ShardLevelMetric]]
       desiredShardLevelMetrics <- x
         .downField("DesiredShardLevelMetrics")
-        .as[List[ShardLevelMetric]]
+        .as[Vector[ShardLevelMetric]]
       streamName <- x.downField("StreamName").as[StreamName]
     } yield EnableEnhancedMonitoringResponse(
       currentShardLevelMetrics,

--- a/src/main/scala/kinesis/mock/api/GetRecordsRequest.scala
+++ b/src/main/scala/kinesis/mock/api/GetRecordsRequest.scala
@@ -166,7 +166,7 @@ object GetRecordsRequest {
     case Some(head) =>
       getRecords(
         data.tail,
-        results :+ head,
+        results.enqueue(head),
         head,
         totalSize + head.size
       )

--- a/src/main/scala/kinesis/mock/api/GetRecordsRequest.scala
+++ b/src/main/scala/kinesis/mock/api/GetRecordsRequest.scala
@@ -2,6 +2,7 @@ package kinesis.mock
 package api
 
 import scala.annotation.tailrec
+import scala.collection.immutable.Queue
 
 import cats.Eq
 import cats.effect.IO
@@ -34,7 +35,7 @@ final case class GetRecordsRequest(
                   CommonValidations
                     .isShardOpen(shard)
                     .flatMap { _ =>
-                      val allShards = stream.shards.keys.toList
+                      val allShards = stream.shards.keys.toVector
                       val childShards = allShards
                         .filter(_.parentShardId.contains(shard.shardId.shardId))
                         .map(s =>
@@ -52,7 +53,7 @@ final case class GetRecordsRequest(
                             childShards,
                             0L,
                             shardIterator,
-                            data
+                            Queue.empty
                           )
                         )
                       } else {
@@ -60,25 +61,18 @@ final case class GetRecordsRequest(
                           parts.sequenceNumber == shard.sequenceNumberRange.startingSequenceNumber
                         ) {
                           val maxRecords = limit.getOrElse(10000)
-                          val firstIndex = 0
-                          val lastIndex =
-                            Math.min(
-                              firstIndex + maxRecords,
-                              data.length
-                            )
 
-                          val records = GetRecordsRequest
+                          val (head, records) = GetRecordsRequest
                             .getRecords(
-                              data.slice(firstIndex, lastIndex),
-                              maxRecords,
-                              List.empty,
-                              0,
+                              data.take(maxRecords),
+                              Queue.empty,
+                              data.head,
                               0
                             )
 
                           val millisBehindLatest =
                             data.last.approximateArrivalTimestamp.toEpochMilli -
-                              records.head.approximateArrivalTimestamp.toEpochMilli
+                              head.approximateArrivalTimestamp.toEpochMilli
 
                           Right(
                             GetRecordsResponse(
@@ -94,40 +88,43 @@ final case class GetRecordsRequest(
                           )
                         } else {
                           data
-                            .find(
+                            .indexWhere(
                               _.sequenceNumber == parts.sequenceNumber
                             ) match {
-                            case Some(record) if record == data.last =>
+                            case -1 =>
+                              ResourceNotFoundException(
+                                s"Record for provided SequenceNumber not found"
+                              ).asLeft
+                            case index if index == data.length - 1 =>
                               Right(
                                 GetRecordsResponse(
                                   childShards,
                                   0L,
                                   shardIterator,
-                                  List.empty
+                                  Queue.empty
                                 )
                               )
 
-                            case Some(record) =>
+                            case index =>
                               val maxRecords = limit.getOrElse(10000)
-                              val firstIndex = data.indexOf(record) + 1
+                              val firstIndex = index + 1
                               val lastIndex =
                                 Math.min(
                                   firstIndex + maxRecords,
                                   data.length
                                 )
 
-                              val records = GetRecordsRequest
+                              val (head, records) = GetRecordsRequest
                                 .getRecords(
                                   data.slice(firstIndex, lastIndex),
-                                  maxRecords,
-                                  List.empty,
-                                  0,
+                                  Queue.empty,
+                                  data(firstIndex),
                                   0
                                 )
 
                               val millisBehindLatest =
                                 data.last.approximateArrivalTimestamp.toEpochMilli -
-                                  record.approximateArrivalTimestamp.toEpochMilli
+                                  head.approximateArrivalTimestamp.toEpochMilli
 
                               Right(
                                 GetRecordsResponse(
@@ -141,11 +138,6 @@ final case class GetRecordsRequest(
                                   records
                                 )
                               )
-
-                            case None =>
-                              ResourceNotFoundException(
-                                s"Record for provided SequenceNumber not found"
-                              ).asLeft
                           }
                         }
                       }
@@ -163,24 +155,20 @@ object GetRecordsRequest {
 
   @tailrec
   def getRecords(
-      data: List[KinesisRecord],
-      maxRecords: Int,
-      results: List[KinesisRecord],
-      totalSize: Int,
-      totalRecords: Int
-  ): List[KinesisRecord] = data match {
-    case Nil =>
-      results
-    case head :: _
-        if head.size + totalSize > maxReturnSize || totalRecords + 1 > maxRecords =>
-      results
-    case head :: tail =>
+      data: Vector[KinesisRecord],
+      results: Queue[KinesisRecord],
+      headResult: KinesisRecord,
+      totalSize: Int
+  ): (KinesisRecord, Queue[KinesisRecord]) = data.headOption match {
+    case None => (headResult, results)
+    case Some(head) if head.size + totalSize > maxReturnSize =>
+      (headResult, results)
+    case Some(head) =>
       getRecords(
-        tail,
-        maxRecords,
+        data.tail,
         results :+ head,
-        totalSize + head.size,
-        totalRecords + 1
+        head,
+        totalSize + head.size
       )
   }
 

--- a/src/main/scala/kinesis/mock/api/GetRecordsResponse.scala
+++ b/src/main/scala/kinesis/mock/api/GetRecordsResponse.scala
@@ -1,6 +1,8 @@
 package kinesis.mock
 package api
 
+import scala.collection.immutable.Queue
+
 import cats.Eq
 import cats.syntax.all._
 import io.circe
@@ -8,10 +10,10 @@ import io.circe
 import kinesis.mock.models._
 
 final case class GetRecordsResponse(
-    childShards: List[ChildShard],
+    childShards: Vector[ChildShard],
     millisBehindLatest: Long,
     nextShardIterator: ShardIterator,
-    records: List[KinesisRecord]
+    records: Queue[KinesisRecord]
 )
 
 object GetRecordsResponse {
@@ -32,10 +34,10 @@ object GetRecordsResponse {
   ): circe.Decoder[GetRecordsResponse] =
     x =>
       for {
-        childShards <- x.downField("ChildShards").as[List[ChildShard]]
+        childShards <- x.downField("ChildShards").as[Vector[ChildShard]]
         millisBehindLatest <- x.downField("MillisBehindLatest").as[Long]
         nextShardIterator <- x.downField("NextShardIterator").as[ShardIterator]
-        records <- x.downField("Records").as[List[KinesisRecord]]
+        records <- x.downField("Records").as[Queue[KinesisRecord]]
       } yield GetRecordsResponse(
         childShards,
         millisBehindLatest,

--- a/src/main/scala/kinesis/mock/api/ListShardsRequest.scala
+++ b/src/main/scala/kinesis/mock/api/ListShardsRequest.scala
@@ -50,7 +50,7 @@ final case class ListShardsRequest(
                 case None     => Right(())
               }
             ).mapN((_, _, stream, _, _) => {
-              val allShards = stream.shards.keys.toList
+              val allShards = stream.shards.keys.toVector.sorted
               val lastShardIndex = allShards.length - 1
               val limit = maxResults.map(l => Math.min(l, 100)).getOrElse(100)
               val firstIndex =
@@ -83,7 +83,7 @@ final case class ListShardsRequest(
                 case None     => Right(())
               }
             ).mapN((_, _, _) => {
-              val allShards: List[Shard] = stream.shards.keys.toList
+              val allShards: Vector[Shard] = stream.shards.keys.toVector.sorted
               val filteredShards = shardFilter match {
                 case Some(sf)
                     if sf.`type` == ShardFilterType.AT_TRIM_HORIZON ||

--- a/src/main/scala/kinesis/mock/api/ListShardsResponse.scala
+++ b/src/main/scala/kinesis/mock/api/ListShardsResponse.scala
@@ -9,7 +9,7 @@ import kinesis.mock.models._
 
 final case class ListShardsResponse(
     nextToken: Option[String],
-    shards: List[ShardSummary]
+    shards: Vector[ShardSummary]
 )
 
 object ListShardsResponse {
@@ -23,7 +23,7 @@ object ListShardsResponse {
     x =>
       for {
         nextToken <- x.downField("NextToken").as[Option[String]]
-        shards <- x.downField("Shards").as[List[ShardSummary]]
+        shards <- x.downField("Shards").as[Vector[ShardSummary]]
       } yield ListShardsResponse(nextToken, shards)
   implicit val listShardsResponseEncoder: Encoder[ListShardsResponse] =
     Encoder.derive

--- a/src/main/scala/kinesis/mock/api/ListStreamConsumersRequest.scala
+++ b/src/main/scala/kinesis/mock/api/ListStreamConsumersRequest.scala
@@ -41,7 +41,7 @@ final case class ListStreamConsumersRequest(
             ).mapN((_, _) =>
               nextToken match {
                 case Some(nt) =>
-                  val allConsumers = stream.consumers.values.toList
+                  val allConsumers = stream.consumers.values.toVector
                   val lastConsumerIndex = allConsumers.length - 1
                   val limit =
                     maxResults.map(l => Math.min(l, 100)).getOrElse(100)
@@ -60,7 +60,7 @@ final case class ListStreamConsumersRequest(
                   )
 
                 case None =>
-                  val allConsumers = stream.consumers.values.toList
+                  val allConsumers = stream.consumers.values.toVector
                   val lastConsumerIndex = allConsumers.length - 1
                   val limit =
                     maxResults.map(l => Math.min(l, 100)).getOrElse(100)

--- a/src/main/scala/kinesis/mock/api/ListStreamConsumersResponse.scala
+++ b/src/main/scala/kinesis/mock/api/ListStreamConsumersResponse.scala
@@ -8,7 +8,7 @@ import io.circe
 import kinesis.mock.models._
 
 final case class ListStreamConsumersResponse(
-    consumers: List[ConsumerSummary],
+    consumers: Vector[ConsumerSummary],
     nextToken: Option[ConsumerName]
 )
 
@@ -25,7 +25,7 @@ object ListStreamConsumersResponse {
   ): circe.Decoder[ListStreamConsumersResponse] =
     x =>
       for {
-        consumers <- x.downField("Consumers").as[List[ConsumerSummary]]
+        consumers <- x.downField("Consumers").as[Vector[ConsumerSummary]]
         nextToken <- x.downField("NextToken").as[Option[ConsumerName]]
       } yield ListStreamConsumersResponse(consumers, nextToken)
 

--- a/src/main/scala/kinesis/mock/api/ListStreamsRequest.scala
+++ b/src/main/scala/kinesis/mock/api/ListStreamsRequest.scala
@@ -28,11 +28,11 @@ final case class ListStreamsRequest(
         case None    => Right(())
       }
     ).mapN((_, _) => {
-      val allStreams = streams.streams.keys.toList
+      val allStreams = streams.streams.keys.toVector.sorted
       val lastStreamIndex = allStreams.length - 1
       val lim = limit.map(l => Math.min(l, 100)).getOrElse(100)
       val firstIndex = exclusiveStartStreamName
-        .map(x => allStreams.indexWhere(_ == x) + 1)
+        .map(x => allStreams.indexOf(x) + 1)
         .getOrElse(0)
       val lastIndex = Math.min(firstIndex + lim, lastStreamIndex + 1)
       val streamNames = allStreams.slice(firstIndex, lastIndex)

--- a/src/main/scala/kinesis/mock/api/ListStreamsResponse.scala
+++ b/src/main/scala/kinesis/mock/api/ListStreamsResponse.scala
@@ -8,7 +8,7 @@ import kinesis.mock.models.StreamName
 
 final case class ListStreamsResponse(
     hasMoreStreams: Boolean,
-    streamNames: List[StreamName]
+    streamNames: Vector[StreamName]
 )
 
 object ListStreamsResponse {
@@ -23,7 +23,7 @@ object ListStreamsResponse {
     x =>
       for {
         hasMoreStreams <- x.downField("HasMoreStreams").as[Boolean]
-        streamNames <- x.downField("StreamNames").as[List[StreamName]]
+        streamNames <- x.downField("StreamNames").as[Vector[StreamName]]
       } yield ListStreamsResponse(hasMoreStreams, streamNames)
   implicit val listStreamsResponseEncoder: Encoder[ListStreamsResponse] =
     Encoder.derive

--- a/src/main/scala/kinesis/mock/api/ListTagsForStreamRequest.scala
+++ b/src/main/scala/kinesis/mock/api/ListTagsForStreamRequest.scala
@@ -1,8 +1,6 @@
 package kinesis.mock
 package api
 
-import scala.collection.SortedMap
-
 import cats.Eq
 import cats.effect.IO
 import cats.effect.concurrent.Ref
@@ -30,7 +28,7 @@ final case class ListTagsForStreamRequest(
               (
                 exclusiveStartTagKey match {
                   case Some(tagKey) =>
-                    CommonValidations.validateTagKeys(List(tagKey))
+                    CommonValidations.validateTagKeys(Vector(tagKey))
                   case None => Right(())
                 },
                 limit match {
@@ -38,14 +36,14 @@ final case class ListTagsForStreamRequest(
                   case None    => Right(())
                 }
               ).mapN((_, _) => {
-                val allTags = stream.tags.toList
+                val allTags = stream.tags.toVector
                 val lastTagIndex = allTags.length - 1
                 val lim = limit.map(l => Math.min(l, 100)).getOrElse(100)
                 val firstIndex = exclusiveStartTagKey
                   .map(x => allTags.indexWhere(_._1 == x) + 1)
                   .getOrElse(0)
                 val lastIndex = Math.min(firstIndex + lim, lastTagIndex + 1)
-                val tags = SortedMap.from(allTags.slice(firstIndex, lastIndex))
+                val tags = Map.from(allTags.slice(firstIndex, lastIndex))
                 val hasMoreTags =
                   if (lastTagIndex + 1 == lastIndex) false
                   else true

--- a/src/main/scala/kinesis/mock/api/MergeShardsRequest.scala
+++ b/src/main/scala/kinesis/mock/api/MergeShardsRequest.scala
@@ -78,7 +78,7 @@ final case class MergeShardsRequest(
             val now = Instant.now()
             val newShardIndex =
               stream.shards.keys.map(_.shardId.index).max + 1
-            val newShard: (Shard, List[KinesisRecord]) = Shard(
+            val newShard: (Shard, Vector[KinesisRecord]) = Shard(
               Some(adjacentShard.shardId.shardId),
               None,
               now,
@@ -102,9 +102,9 @@ final case class MergeShardsRequest(
                 else shard.sequenceNumberRange.startingSequenceNumber
               ),
               ShardId.create(newShardIndex)
-            ) -> List.empty
+            ) -> Vector.empty
 
-            val oldShards: List[(Shard, List[KinesisRecord])] = List(
+            val oldShards: Vector[(Shard, Vector[KinesisRecord])] = Vector(
               adjacentShard.copy(
                 closedTimestamp = Some(now),
                 sequenceNumberRange = adjacentShard.sequenceNumberRange

--- a/src/main/scala/kinesis/mock/api/PutRecordRequest.scala
+++ b/src/main/scala/kinesis/mock/api/PutRecordRequest.scala
@@ -1,8 +1,6 @@
 package kinesis.mock
 package api
 
-import scala.collection.SortedMap
-
 import java.time.Instant
 
 import cats.Eq
@@ -78,7 +76,7 @@ final case class PutRecordRequest(
           .update(x =>
             x.updateStream {
               stream.copy(
-                shards = stream.shards ++ SortedMap(
+                shards = stream.shards ++ Map(
                   shard -> (records :+ KinesisRecord(
                     now,
                     data,

--- a/src/main/scala/kinesis/mock/api/PutRecordsRequest.scala
+++ b/src/main/scala/kinesis/mock/api/PutRecordsRequest.scala
@@ -13,7 +13,7 @@ import kinesis.mock.models._
 import kinesis.mock.validations.CommonValidations
 
 final case class PutRecordsRequest(
-    records: List[PutRecordsRequestEntry],
+    records: Vector[PutRecordsRequestEntry],
     streamName: StreamName
 ) {
   def putRecords(
@@ -84,7 +84,7 @@ final case class PutRecordsRequest(
                   )
                 }
             }
-            .toList
+            .toVector
 
           val newShards = grouped.map {
             case ((shard, currentRecords), recordsToAdd) =>
@@ -129,7 +129,7 @@ object PutRecordsRequest {
   implicit val putRecordsRequestCirceDecoder: circe.Decoder[PutRecordsRequest] =
     x =>
       for {
-        records <- x.downField("Records").as[List[PutRecordsRequestEntry]]
+        records <- x.downField("Records").as[Vector[PutRecordsRequestEntry]]
         streamName <- x.downField("StreamName").as[StreamName]
       } yield PutRecordsRequest(records, streamName)
 

--- a/src/main/scala/kinesis/mock/api/PutRecordsResponse.scala
+++ b/src/main/scala/kinesis/mock/api/PutRecordsResponse.scala
@@ -9,7 +9,7 @@ import kinesis.mock.models.EncryptionType
 final case class PutRecordsResponse(
     encryptionType: EncryptionType,
     failedRecordCount: Int,
-    records: List[PutRecordsResultEntry]
+    records: Vector[PutRecordsResultEntry]
 )
 
 object PutRecordsResponse {
@@ -27,7 +27,7 @@ object PutRecordsResponse {
       for {
         encryptionType <- x.downField("EncryptionType").as[EncryptionType]
         failedRecordCount <- x.downField("FailedRecordCount").as[Int]
-        records <- x.downField("Records").as[List[PutRecordsResultEntry]]
+        records <- x.downField("Records").as[Vector[PutRecordsResultEntry]]
       } yield PutRecordsResponse(encryptionType, failedRecordCount, records)
 
   implicit val putRecordsResponseEncoder: Encoder[PutRecordsResponse] =

--- a/src/main/scala/kinesis/mock/api/RegisterStreamConsumerRequest.scala
+++ b/src/main/scala/kinesis/mock/api/RegisterStreamConsumerRequest.scala
@@ -56,7 +56,7 @@ final case class RegisterStreamConsumerRequest(
               x.updateStream(
                 stream
                   .copy(consumers =
-                    stream.consumers ++ Vector(consumerName -> consumer)
+                    stream.consumers + (consumerName -> consumer)
                   )
               )
             )

--- a/src/main/scala/kinesis/mock/api/RegisterStreamConsumerRequest.scala
+++ b/src/main/scala/kinesis/mock/api/RegisterStreamConsumerRequest.scala
@@ -56,7 +56,7 @@ final case class RegisterStreamConsumerRequest(
               x.updateStream(
                 stream
                   .copy(consumers =
-                    stream.consumers ++ List(consumerName -> consumer)
+                    stream.consumers ++ Vector(consumerName -> consumer)
                   )
               )
             )

--- a/src/main/scala/kinesis/mock/api/RemoveTagsFromStreamRequest.scala
+++ b/src/main/scala/kinesis/mock/api/RemoveTagsFromStreamRequest.scala
@@ -12,7 +12,7 @@ import kinesis.mock.validations.CommonValidations
 
 final case class RemoveTagsFromStreamRequest(
     streamName: StreamName,
-    tagKeys: List[String]
+    tagKeys: Vector[String]
 ) {
   // https://docs.aws.amazon.com/kinesis/latest/APIReference/API_RemoveTagsFromStream.html
   // https://docs.aws.amazon.com/streams/latest/dev/tagging.html
@@ -56,7 +56,7 @@ object RemoveTagsFromStreamRequest {
       : circe.Decoder[RemoveTagsFromStreamRequest] = { x =>
     for {
       streamName <- x.downField("StreamName").as[StreamName]
-      tagKeys <- x.downField("TagKeys").as[List[String]]
+      tagKeys <- x.downField("TagKeys").as[Vector[String]]
     } yield RemoveTagsFromStreamRequest(streamName, tagKeys)
   }
   implicit val removeTagsFromStreamRequestEncoder

--- a/src/main/scala/kinesis/mock/api/SplitShardRequest.scala
+++ b/src/main/scala/kinesis/mock/api/SplitShardRequest.scala
@@ -68,7 +68,7 @@ final case class SplitShardRequest(
           val newStartingHashKeyNumber = BigInt(newStartingHashKey)
           val newShardIndex1 = stream.shards.keys.map(_.shardId.index).max + 1
           val newShardIndex2 = newShardIndex1 + 1
-          val newShard1: (Shard, List[KinesisRecord]) = Shard(
+          val newShard1: (Shard, Vector[KinesisRecord]) = Shard(
             None,
             None,
             now,
@@ -82,9 +82,9 @@ final case class SplitShardRequest(
               SequenceNumber.create(now, newShardIndex1, None, None, None)
             ),
             ShardId.create(newShardIndex1)
-          ) -> List.empty
+          ) -> Vector.empty
 
-          val newShard2: (Shard, List[KinesisRecord]) = Shard(
+          val newShard2: (Shard, Vector[KinesisRecord]) = Shard(
             None,
             None,
             now,
@@ -98,11 +98,11 @@ final case class SplitShardRequest(
               SequenceNumber.create(now, newShardIndex2, None, None, None)
             ),
             ShardId.create(newShardIndex2)
-          ) -> List.empty
+          ) -> Vector.empty
 
-          val newShards = List(newShard1, newShard2)
+          val newShards = Vector(newShard1, newShard2)
 
-          val oldShard: (Shard, List[KinesisRecord]) = shard.copy(
+          val oldShard: (Shard, Vector[KinesisRecord]) = shard.copy(
             closedTimestamp = Some(now),
             sequenceNumberRange = shard.sequenceNumberRange.copy(
               endingSequenceNumber = Some(SequenceNumber.shardEnd)

--- a/src/main/scala/kinesis/mock/api/UpdateShardCountRequest.scala
+++ b/src/main/scala/kinesis/mock/api/UpdateShardCountRequest.scala
@@ -70,7 +70,7 @@ final case class UpdateShardCountRequest(
             }
         )
         .traverse { stream =>
-          val shards = stream.shards.toList
+          val shards = stream.shards.toVector
           val oldShards = shards.map { case (shard, data) =>
             (
               shard.copy(

--- a/src/main/scala/kinesis/mock/cache/Cache.scala
+++ b/src/main/scala/kinesis/mock/cache/Cache.scala
@@ -427,7 +427,7 @@ class Cache private (
                             .fold(x)(stream =>
                               x.updateStream(
                                 stream.copy(consumers =
-                                  stream.consumers ++ List(
+                                  stream.consumers ++ Vector(
                                     r.consumer.consumerName -> Consumer(
                                       r.consumer.consumerArn,
                                       r.consumer.consumerCreationTimestamp,
@@ -497,7 +497,7 @@ class Cache private (
                         streamsRef.update(x =>
                           x.streams.values
                             .find(s =>
-                              s.consumers.keys.toList
+                              s.consumers.keys.toVector
                                 .contains(consumer.consumerName)
                             )
                             .fold(x)(stream =>
@@ -1200,7 +1200,7 @@ class Cache private (
         semaphores.persistData.withPermit(
           for {
             streams <- streamsRef.get
-            ctx = context ++ List(
+            ctx = context ++ Vector(
               "fileName" -> config.persistConfig.fileName,
               "path" -> config.persistConfig.osPath.toString
             )

--- a/src/main/scala/kinesis/mock/cache/CacheConfig.scala
+++ b/src/main/scala/kinesis/mock/cache/CacheConfig.scala
@@ -51,7 +51,7 @@ object CacheConfig {
         .toRight(
           CannotConvert(
             s,
-            "List[CreateStreamRequest]",
+            "Vector[CreateStreamRequest]",
             "Invalid format. Expected: \"<String>:<Int>,<String>:<Int>,...\""
           )
         )

--- a/src/main/scala/kinesis/mock/instances/circe.scala
+++ b/src/main/scala/kinesis/mock/instances/circe.scala
@@ -1,6 +1,5 @@
 package kinesis.mock.instances
 
-import scala.collection.SortedMap
 import scala.concurrent.duration.FiniteDuration
 import scala.util.Try
 
@@ -9,7 +8,7 @@ import java.util.Base64
 import java.util.concurrent.TimeUnit
 
 import io.circe.syntax._
-import io.circe.{Decoder, Encoder, JsonObject, KeyDecoder, KeyEncoder}
+import io.circe.{Decoder, Encoder, JsonObject}
 import os.Path
 
 object circe {
@@ -71,13 +70,6 @@ object circe {
 
   implicit val arrayBytesCirceDecoder: Decoder[Array[Byte]] =
     Decoder[String].map(str => Base64.getDecoder.decode(str))
-
-  implicit def sortedMapCirceEncoder[K: KeyEncoder, V: Encoder]
-      : Encoder[SortedMap[K, V]] = Encoder[Map[K, V]].contramap(_.toMap)
-
-  implicit def sortedMapCirceDecoder[K: KeyDecoder: Ordering, V: Decoder]
-      : Decoder[SortedMap[K, V]] =
-    Decoder[Map[K, V]].map(x => SortedMap.from(x))
 
   implicit val pathCirceEncoder: Encoder[Path] =
     Encoder[String].contramap(_.toString())

--- a/src/main/scala/kinesis/mock/instances/http4s.scala
+++ b/src/main/scala/kinesis/mock/instances/http4s.scala
@@ -15,7 +15,7 @@ object http4s {
   implicit def kinesisMockEntityDecoder[A: Decoder]: EntityDecoder[IO, A] =
     EntityDecoder.decodeBy[IO, A](
       KinesisMockMediaTypes.validContentTypes.head,
-      KinesisMockMediaTypes.validContentTypes.tail.toList: _*
+      KinesisMockMediaTypes.validContentTypes.tail.toVector: _*
     ) { msg =>
       msg.contentType match {
         case Some(ct)

--- a/src/main/scala/kinesis/mock/models/ChildShard.scala
+++ b/src/main/scala/kinesis/mock/models/ChildShard.scala
@@ -6,12 +6,12 @@ import io.circe
 
 final case class ChildShard(
     hashKeyRange: HashKeyRange,
-    parentShards: List[String],
+    parentShards: Vector[String],
     shardId: String
 )
 
 object ChildShard {
-  def fromShard(shard: Shard, parentShards: List[Shard]): ChildShard =
+  def fromShard(shard: Shard, parentShards: Vector[Shard]): ChildShard =
     ChildShard(
       shard.hashKeyRange,
       parentShards.map(_.shardId.shardId),
@@ -26,7 +26,7 @@ object ChildShard {
   implicit val childShardCirceDecoder: circe.Decoder[ChildShard] = x =>
     for {
       hashKeyRange <- x.downField("HashKeyRange").as[HashKeyRange]
-      parentShards <- x.downField("ParentShards").as[List[String]]
+      parentShards <- x.downField("ParentShards").as[Vector[String]]
       shardId <- x.downField("ShardId").as[String]
     } yield ChildShard(hashKeyRange, parentShards, shardId)
   implicit val childShardEncoder: Encoder[ChildShard] =

--- a/src/main/scala/kinesis/mock/models/Shard.scala
+++ b/src/main/scala/kinesis/mock/models/Shard.scala
@@ -1,8 +1,6 @@
 package kinesis.mock
 package models
 
-import scala.collection.SortedMap
-
 import java.time.Instant
 
 import cats.Eq
@@ -33,10 +31,10 @@ object Shard {
       shardCount: Int,
       createTime: Instant,
       startingIndex: Int
-  ): SortedMap[Shard, List[KinesisRecord]] = {
+  ): Map[Shard, Vector[KinesisRecord]] = {
     val shardHash = maxHashKey / BigInt(shardCount)
-    SortedMap.from(
-      List
+    Map.from(
+      Vector
         .range(startingIndex, shardCount + startingIndex, 1)
         .zipWithIndex
         .map { case (shardIndex, listIndex) =>
@@ -56,7 +54,7 @@ object Shard {
               SequenceNumber.create(createTime, shardIndex, None, None, None)
             ),
             ShardId.create(shardIndex)
-          ) -> List.empty
+          ) -> Vector.empty
         }
     )
   }

--- a/src/main/scala/kinesis/mock/models/ShardIterator.scala
+++ b/src/main/scala/kinesis/mock/models/ShardIterator.scala
@@ -90,12 +90,12 @@ object ShardIterator {
       sequenceNumber: SequenceNumber
   ): ShardIterator = {
     val encryptString =
-      (List.fill(14)("0").mkString + Instant.now().toEpochMilli)
+      (Vector.fill(14)("0").mkString + Instant.now().toEpochMilli)
         .takeRight(14) +
         s"/$streamName" +
         s"/$shardId" +
         s"/${sequenceNumber.value}/" +
-        List.fill(37)("0").mkString
+        Vector.fill(37)("0").mkString
 
     val cipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
     cipher.init(Cipher.ENCRYPT_MODE, iteratorPwdKey, iteratorPwdIv)

--- a/src/main/scala/kinesis/mock/models/ShardLevelMetrics.scala
+++ b/src/main/scala/kinesis/mock/models/ShardLevelMetrics.scala
@@ -4,7 +4,7 @@ package models
 import cats.Eq
 import io.circe
 
-final case class ShardLevelMetrics(shardLevelMetrics: List[ShardLevelMetric])
+final case class ShardLevelMetrics(shardLevelMetrics: Vector[ShardLevelMetric])
 
 object ShardLevelMetrics {
   implicit val shardLevelMetricsCirceEncoder: circe.Encoder[ShardLevelMetrics] =
@@ -12,7 +12,7 @@ object ShardLevelMetrics {
   implicit val shardLevelMetricsCirceDecoder
       : circe.Decoder[ShardLevelMetrics] = {
     _.downField("ShardLevelMetrics")
-      .as[List[ShardLevelMetric]]
+      .as[Vector[ShardLevelMetric]]
       .map(ShardLevelMetrics.apply)
   }
   implicit val shardLevelMetricsEncoder: Encoder[ShardLevelMetrics] =

--- a/src/main/scala/kinesis/mock/models/StreamData.scala
+++ b/src/main/scala/kinesis/mock/models/StreamData.scala
@@ -1,7 +1,6 @@
 package kinesis.mock
 package models
 
-import scala.collection.SortedMap
 import scala.concurrent.duration._
 
 import java.time.Instant
@@ -14,18 +13,18 @@ import io.circe.derivation._
 import kinesis.mock.instances.circe._
 
 final case class StreamData(
-    consumers: SortedMap[ConsumerName, Consumer],
+    consumers: Map[ConsumerName, Consumer],
     encryptionType: EncryptionType,
-    enhancedMonitoring: List[ShardLevelMetrics],
+    enhancedMonitoring: Vector[ShardLevelMetrics],
     keyId: Option[String],
     retentionPeriod: FiniteDuration,
-    shards: SortedMap[Shard, List[KinesisRecord]],
+    shards: Map[Shard, Vector[KinesisRecord]],
     streamArn: String,
     streamCreationTimestamp: Instant,
     streamName: StreamName,
     streamStatus: StreamStatus,
     tags: Tags,
-    shardCountUpdates: List[Instant]
+    shardCountUpdates: Vector[Instant]
 )
 
 object StreamData {
@@ -68,12 +67,12 @@ object StreamData {
   ): StreamData = {
 
     val createTime = Instant.now()
-    val shards: SortedMap[Shard, List[KinesisRecord]] =
+    val shards: Map[Shard, Vector[KinesisRecord]] =
       Shard.newShards(shardCount, createTime, 0)
     StreamData(
-      SortedMap.empty,
+      Map.empty,
       EncryptionType.NONE,
-      List(ShardLevelMetrics(List.empty)),
+      Vector(ShardLevelMetrics(Vector.empty)),
       None,
       minRetentionPeriod,
       shards,
@@ -82,7 +81,7 @@ object StreamData {
       streamName,
       StreamStatus.CREATING,
       Tags.empty,
-      List.empty
+      Vector.empty
     )
   }
 }

--- a/src/main/scala/kinesis/mock/models/StreamDescription.scala
+++ b/src/main/scala/kinesis/mock/models/StreamDescription.scala
@@ -11,11 +11,11 @@ import kinesis.mock.instances.circe._
 
 final case class StreamDescription(
     encryptionType: Option[EncryptionType],
-    enhancedMonitoring: List[ShardLevelMetrics],
+    enhancedMonitoring: Vector[ShardLevelMetrics],
     hasMoreShards: Boolean,
     keyId: Option[String],
     retentionPeriodHours: Int,
-    shards: List[ShardSummary],
+    shards: Vector[ShardSummary],
     streamArn: String,
     streamCreationTimestamp: Instant,
     streamName: StreamName,
@@ -28,10 +28,10 @@ object StreamDescription {
       exclusiveStartShardId: Option[String],
       limit: Option[Int]
   ): StreamDescription = {
-    val allShards = streamData.shards.keys.toList
+    val allShards = streamData.shards.keys.toVector
     val lim = Math.min(limit.getOrElse(100), 100)
 
-    val (shards: List[Shard], hasMoreShards: Boolean) =
+    val (shards: Vector[Shard], hasMoreShards: Boolean) =
       exclusiveStartShardId match {
         case None =>
           val s = allShards.take(lim)
@@ -96,11 +96,11 @@ object StreamDescription {
         .as[Option[EncryptionType]]
       enhancedMonitoring <- x
         .downField("EnhancedMonitoring")
-        .as[List[ShardLevelMetrics]]
+        .as[Vector[ShardLevelMetrics]]
       hasMoreShards <- x.downField("HasMoreShards").as[Boolean]
       keyId <- x.downField("KeyId").as[Option[String]]
       retentionPeriodHours <- x.downField("RetentionPeriodHours").as[Int]
-      shards <- x.downField("Shards").as[List[ShardSummary]]
+      shards <- x.downField("Shards").as[Vector[ShardSummary]]
       streamArn <- x.downField("StreamARN").as[String]
       streamCreationTimestamp <- x
         .downField("StreamCreationTimestamp")

--- a/src/main/scala/kinesis/mock/models/StreamDescriptionSummary.scala
+++ b/src/main/scala/kinesis/mock/models/StreamDescriptionSummary.scala
@@ -11,7 +11,7 @@ import kinesis.mock.instances.circe._
 final case class StreamDescriptionSummary(
     consumerCount: Option[Int],
     encryptionType: Option[EncryptionType],
-    enhancedMonitoring: List[ShardLevelMetrics],
+    enhancedMonitoring: Vector[ShardLevelMetrics],
     keyId: Option[String],
     openShardCount: Int,
     retentionPeriodHours: Int,
@@ -72,7 +72,7 @@ object StreamDescriptionSummary {
       encryptionType <- x.downField("EncryptionType").as[Option[EncryptionType]]
       enhancedMonitoring <- x
         .downField("EnhancedMonitoring")
-        .as[List[ShardLevelMetrics]]
+        .as[Vector[ShardLevelMetrics]]
       keyId <- x.downField("KeyId").as[Option[String]]
       openShardCount <- x.downField("OpenShardCount").as[Int]
       retentionPeriodHours <- x.downField("RetentionPeriodHours").as[Int]

--- a/src/main/scala/kinesis/mock/models/Streams.scala
+++ b/src/main/scala/kinesis/mock/models/Streams.scala
@@ -1,66 +1,60 @@
 package kinesis.mock
 package models
 
-import scala.collection.SortedMap
-
 import cats.Eq
 import cats.syntax.all._
 import io.circe._
 import io.circe.derivation._
 
-final case class Streams(streams: SortedMap[StreamName, StreamData]) {
+final case class Streams(streams: Map[StreamName, StreamData]) {
   def updateStream(stream: StreamData): Streams =
-    copy(streams = streams ++ List(stream.streamName -> stream))
+    copy(streams = streams + (stream.streamName -> stream))
   def findAndUpdateStream(
       streamName: StreamName
   )(f: StreamData => StreamData): Streams =
-    copy(
-      streams = streams ++
-        streams
-          .get(streamName)
-          .map(stream => (stream.streamName, f(stream)))
-          .toMap
-    )
+    streams
+      .get(streamName)
+      .map(stream => copy(streams = streams + (stream.streamName -> f(stream))))
+      .getOrElse(this)
+
   def addStream(
       shardCount: Int,
       streamName: StreamName,
       awsRegion: AwsRegion,
       awsAccountId: AwsAccountId
-  ): Streams = {
-    val created = StreamData.create(
-      shardCount,
-      streamName,
-      awsRegion,
-      awsAccountId
+  ): Streams =
+    copy(streams =
+      streams + (streamName -> StreamData.create(
+        shardCount,
+        streamName,
+        awsRegion,
+        awsAccountId
+      ))
     )
-
-    copy(streams = streams ++ List(streamName -> created))
-  }
 
   def deleteStream(
       streamName: StreamName
-  ): Streams =
-    copy(streams =
-      streams ++ streams
-        .get(streamName)
-        .map(stream =>
-          streamName -> stream.copy(
-            shards = SortedMap.empty,
-            streamStatus = StreamStatus.DELETING,
-            tags = Tags.empty,
-            enhancedMonitoring = List.empty,
-            consumers = SortedMap.empty
-          )
-        )
-        .toMap
+  ): Streams = streams
+    .get(streamName)
+    .map(stream =>
+      copy(streams =
+        streams + (streamName -> stream.copy(
+          shards = Map.empty,
+          streamStatus = StreamStatus.DELETING,
+          tags = Tags.empty,
+          enhancedMonitoring = Vector.empty,
+          consumers = Map.empty
+        ))
+      )
     )
+    .getOrElse(this)
 
   def removeStream(streamName: StreamName): Streams =
-    copy(streams = streams.filterNot { case (sName, _) => sName == streamName })
+    copy(streams = streams - streamName)
 }
 
 object Streams {
-  val empty: Streams = Streams(SortedMap.empty)
+  val empty: Streams = Streams(Map.empty)
   implicit val streamsCirceEncoder: Encoder[Streams] = deriveEncoder
   implicit val streamsCirceDecoder: Decoder[Streams] = deriveDecoder
   implicit val streamsEq: Eq[Streams] = (x, y) =>

--- a/src/main/scala/kinesis/mock/models/TagList.scala
+++ b/src/main/scala/kinesis/mock/models/TagList.scala
@@ -3,15 +3,15 @@ package kinesis.mock.models
 import cats.Eq
 import io.circe._
 
-final case class TagList(tags: List[TagListEntry])
+final case class TagList(tags: Vector[TagListEntry])
 
 object TagList {
   implicit val tagListEq: Eq[TagList] = Eq.fromUniversalEquals
   implicit val tagListCirceEncoder: Encoder[TagList] =
-    Encoder.encodeList[TagListEntry].contramap(_.tags)
+    Encoder.encodeVector[TagListEntry].contramap(_.tags)
   implicit val tagListCirceDecoder: Decoder[TagList] =
-    Decoder[List[TagListEntry]].map(TagList.apply)
+    Decoder[Vector[TagListEntry]].map(TagList.apply)
   def fromTags(tags: Tags): TagList = TagList(
-    tags.tags.toList.map { case (key, value) => TagListEntry(key, value) }
+    tags.tags.toVector.map { case (key, value) => TagListEntry(key, value) }
   )
 }

--- a/src/main/scala/kinesis/mock/models/Tags.scala
+++ b/src/main/scala/kinesis/mock/models/Tags.scala
@@ -1,28 +1,26 @@
 package kinesis.mock.models
 
-import scala.collection.SortedMap
-
 import cats.{Eq, Monoid}
 import io.circe._
 
-final case class Tags(tags: SortedMap[String, String]) {
+final case class Tags(tags: Map[String, String]) {
   def size: Int = tags.size
   def --(keys: IterableOnce[String]): Tags = copy(tags = tags.filterNot {
     case (key, _) => keys.iterator.contains(key)
   })
   override def toString: String = tags.toString()
-  def toList: List[(String, String)] = tags.toList
+  def toVector: Vector[(String, String)] = tags.toVector
 }
 
 object Tags {
-  def empty: Tags = Tags(SortedMap.empty)
+  def empty: Tags = Tags(Map.empty)
   def fromTagList(tagList: TagList): Tags = Tags(
-    SortedMap.from(tagList.tags.map(x => (x.key, x.value)))
+    Map.from(tagList.tags.map(x => (x.key, x.value)))
   )
   implicit val tagsCirceEncoder: Encoder[Tags] =
-    Encoder[SortedMap[String, String]].contramap(_.tags)
+    Encoder[Map[String, String]].contramap(_.tags)
   implicit val tagsCirceDecoder: Decoder[Tags] =
-    Decoder[SortedMap[String, String]].map(Tags.apply)
+    Decoder[Map[String, String]].map(Tags.apply)
   implicit val tagsEq: Eq[Tags] = Eq.fromUniversalEquals
   implicit val tagsMonoid: Monoid[Tags] = new Monoid[Tags] {
     override def combine(x: Tags, y: Tags): Tags = Tags(x.tags ++ y.tags)

--- a/src/main/scala/kinesis/mock/validations/CommonValidations.scala
+++ b/src/main/scala/kinesis/mock/validations/CommonValidations.scala
@@ -298,7 +298,7 @@ object CommonValidations {
   def findShard(
       shardId: String,
       stream: StreamData
-  ): Response[(Shard, List[KinesisRecord])] =
+  ): Response[(Shard, Vector[KinesisRecord])] =
     stream.shards.find { case (shard, _) =>
       shard.shardId.shardId == shardId
     } match {
@@ -313,7 +313,7 @@ object CommonValidations {
       partitionKey: String,
       explicitHashKey: Option[String],
       stream: StreamData
-  ): Response[(Shard, List[KinesisRecord])] = {
+  ): Response[(Shard, Vector[KinesisRecord])] = {
     (explicitHashKey match {
       case Some(ehk) =>
         val hash = BigInt(ehk)

--- a/src/test/scala/kinesis/mock/api/AddTagsToStreamTests.scala
+++ b/src/test/scala/kinesis/mock/api/AddTagsToStreamTests.scala
@@ -1,8 +1,6 @@
 package kinesis.mock
 package api
 
-import scala.collection.SortedMap
-
 import cats.effect.IO
 import cats.effect.concurrent.Ref
 import enumeratum.scalacheck._
@@ -49,8 +47,8 @@ class AddTagsToStreamTests
 
       val tagKey = tagKeyGen.one
       val tagValue = tagValueGen.one
-      val tags = Tags(SortedMap(tagKey -> tagValue))
-      val initialTags = Tags(SortedMap(tagKey -> "initial"))
+      val tags = Tags(Map(tagKey -> tagValue))
+      val initialTags = Tags(Map(tagKey -> "initial"))
 
       val streamsWithTag = streams.findAndUpdateStream(streamName)(stream =>
         stream.copy(tags = initialTags)

--- a/src/test/scala/kinesis/mock/api/DeleteStreamTests.scala
+++ b/src/test/scala/kinesis/mock/api/DeleteStreamTests.scala
@@ -1,7 +1,5 @@
 package kinesis.mock.api
 
-import scala.collection.SortedMap
-
 import cats.effect.IO
 import cats.effect.concurrent.Ref
 import enumeratum.scalacheck._
@@ -86,7 +84,7 @@ class DeleteStreamTests
 
       val withConsumers = streams.findAndUpdateStream(streamName)(x =>
         x.copy(consumers =
-          SortedMap(consumerName -> Consumer.create(x.streamArn, consumerName))
+          Map(consumerName -> Consumer.create(x.streamArn, consumerName))
         )
       )
 

--- a/src/test/scala/kinesis/mock/api/DeregisterStreamConsumerTests.scala
+++ b/src/test/scala/kinesis/mock/api/DeregisterStreamConsumerTests.scala
@@ -1,8 +1,6 @@
 package kinesis.mock
 package api
 
-import scala.collection.SortedMap
-
 import cats.effect.IO
 import cats.effect.concurrent.Ref
 import enumeratum.scalacheck._
@@ -26,7 +24,7 @@ class DeregisterStreamConsumerTests
       val updated = streams.findAndUpdateStream(streamName) { stream =>
         stream.copy(
           streamStatus = StreamStatus.ACTIVE,
-          consumers = SortedMap(
+          consumers = Map(
             consumerName -> Consumer
               .create(stream.streamArn, consumerName)
               .copy(consumerStatus = ConsumerStatus.ACTIVE)
@@ -67,7 +65,7 @@ class DeregisterStreamConsumerTests
       val updated = streams.findAndUpdateStream(streamName) { stream =>
         stream.copy(
           streamStatus = StreamStatus.ACTIVE,
-          consumers = SortedMap(
+          consumers = Map(
             consumerName -> Consumer
               .create(stream.streamArn, consumerName)
               .copy(consumerStatus = ConsumerStatus.ACTIVE)
@@ -107,7 +105,7 @@ class DeregisterStreamConsumerTests
       val updated = streams.findAndUpdateStream(streamName) { stream =>
         stream.copy(
           streamStatus = StreamStatus.ACTIVE,
-          consumers = SortedMap(
+          consumers = Map(
             consumerName -> Consumer
               .create(stream.streamArn, consumerName)
           )
@@ -168,7 +166,7 @@ class DeregisterStreamConsumerTests
       val updated = streams.findAndUpdateStream(streamName) { stream =>
         stream.copy(
           streamStatus = StreamStatus.ACTIVE,
-          consumers = SortedMap(
+          consumers = Map(
             consumerName -> Consumer
               .create(stream.streamArn, consumerName)
               .copy(consumerStatus = ConsumerStatus.ACTIVE)
@@ -200,7 +198,7 @@ class DeregisterStreamConsumerTests
       val updated = streams.findAndUpdateStream(streamName) { stream =>
         stream.copy(
           streamStatus = StreamStatus.ACTIVE,
-          consumers = SortedMap(
+          consumers = Map(
             consumerName -> Consumer
               .create(stream.streamArn, consumerName)
               .copy(consumerStatus = ConsumerStatus.ACTIVE)

--- a/src/test/scala/kinesis/mock/api/DescribeStreamConsumerTests.scala
+++ b/src/test/scala/kinesis/mock/api/DescribeStreamConsumerTests.scala
@@ -1,8 +1,6 @@
 package kinesis.mock
 package api
 
-import scala.collection.SortedMap
-
 import cats.effect.IO
 import cats.effect.concurrent.Ref
 import enumeratum.scalacheck._
@@ -26,7 +24,7 @@ class DescribeStreamConsumerTests
       val updated = streams.findAndUpdateStream(streamName) { stream =>
         stream.copy(
           streamStatus = StreamStatus.ACTIVE,
-          consumers = SortedMap(
+          consumers = Map(
             consumerName -> Consumer
               .create(stream.streamArn, consumerName)
               .copy(consumerStatus = ConsumerStatus.ACTIVE)
@@ -63,7 +61,7 @@ class DescribeStreamConsumerTests
       val updated = streams.findAndUpdateStream(streamName) { stream =>
         stream.copy(
           streamStatus = StreamStatus.ACTIVE,
-          consumers = SortedMap(
+          consumers = Map(
             consumerName -> Consumer
               .create(stream.streamArn, consumerName)
               .copy(consumerStatus = ConsumerStatus.ACTIVE)
@@ -122,7 +120,7 @@ class DescribeStreamConsumerTests
       val updated = streams.findAndUpdateStream(streamName) { stream =>
         stream.copy(
           streamStatus = StreamStatus.ACTIVE,
-          consumers = SortedMap(
+          consumers = Map(
             consumerName -> Consumer
               .create(stream.streamArn, consumerName)
               .copy(consumerStatus = ConsumerStatus.ACTIVE)
@@ -151,7 +149,7 @@ class DescribeStreamConsumerTests
       val updated = streams.findAndUpdateStream(streamName) { stream =>
         stream.copy(
           streamStatus = StreamStatus.ACTIVE,
-          consumers = SortedMap(
+          consumers = Map(
             consumerName -> Consumer
               .create(stream.streamArn, consumerName)
               .copy(consumerStatus = ConsumerStatus.ACTIVE)

--- a/src/test/scala/kinesis/mock/api/DisableEnhancedMonitoringTests.scala
+++ b/src/test/scala/kinesis/mock/api/DisableEnhancedMonitoringTests.scala
@@ -24,9 +24,9 @@ class DisableEnhancedMonitoringTests
 
       val updated = streams.findAndUpdateStream(streamName)(stream =>
         stream.copy(enhancedMonitoring =
-          List(
+          Vector(
             ShardLevelMetrics(
-              List(
+              Vector(
                 ShardLevelMetric.IncomingBytes,
                 ShardLevelMetric.IncomingRecords,
                 ShardLevelMetric.OutgoingBytes,

--- a/src/test/scala/kinesis/mock/api/GetRecordsTests.scala
+++ b/src/test/scala/kinesis/mock/api/GetRecordsTests.scala
@@ -1,8 +1,6 @@
 package kinesis.mock
 package api
 
-import scala.collection.SortedMap
-
 import cats.effect.IO
 import cats.effect.concurrent.Ref
 import cats.syntax.all._
@@ -27,8 +25,8 @@ class GetRecordsTests
 
       val shard = streams.streams(streamName).shards.head._1
 
-      val records: List[KinesisRecord] =
-        kinesisRecordArbitrary.arbitrary.take(100).toList.zipWithIndex.map {
+      val records: Vector[KinesisRecord] =
+        kinesisRecordArbitrary.arbitrary.take(100).toVector.zipWithIndex.map {
           case (record, index) =>
             record.copy(sequenceNumber =
               SequenceNumber.create(
@@ -43,7 +41,7 @@ class GetRecordsTests
 
       val withRecords = streams.findAndUpdateStream(streamName) { s =>
         s.copy(
-          shards = SortedMap(s.shards.head._1 -> records),
+          shards = Map(s.shards.head._1 -> records),
           streamStatus = StreamStatus.ACTIVE
         )
       }
@@ -60,7 +58,7 @@ class GetRecordsTests
         res <- req.getRecords(streamsRef)
       } yield assert(
         res.isRight && res.exists { response =>
-          response.records === records
+          response.records.toVector === records
         },
         s"req: $req\n" +
           s"resCount: ${res.map(_.records.length)}\n" +
@@ -80,8 +78,8 @@ class GetRecordsTests
 
       val shard = streams.streams(streamName).shards.head._1
 
-      val records: List[KinesisRecord] =
-        kinesisRecordArbitrary.arbitrary.take(100).toList.zipWithIndex.map {
+      val records: Vector[KinesisRecord] =
+        kinesisRecordArbitrary.arbitrary.take(100).toVector.zipWithIndex.map {
           case (record, index) =>
             record.copy(sequenceNumber =
               SequenceNumber.create(
@@ -96,7 +94,7 @@ class GetRecordsTests
 
       val withRecords = streams.findAndUpdateStream(streamName) { s =>
         s.copy(
-          shards = SortedMap(s.shards.head._1 -> records),
+          shards = Map(s.shards.head._1 -> records),
           streamStatus = StreamStatus.ACTIVE
         )
       }
@@ -113,7 +111,7 @@ class GetRecordsTests
         res <- req.getRecords(streamsRef)
       } yield assert(
         res.isRight && res.exists { response =>
-          response.records === records.take(50)
+          response.records.toVector === records.take(50)
         },
         s"req: $req\n" +
           s"resCount: ${res.map(_.records.length)}\n" +
@@ -133,8 +131,8 @@ class GetRecordsTests
 
       val shard = streams.streams(streamName).shards.head._1
 
-      val records: List[KinesisRecord] =
-        kinesisRecordArbitrary.arbitrary.take(100).toList.zipWithIndex.map {
+      val records: Vector[KinesisRecord] =
+        kinesisRecordArbitrary.arbitrary.take(100).toVector.zipWithIndex.map {
           case (record, index) =>
             record.copy(sequenceNumber =
               SequenceNumber.create(
@@ -149,7 +147,7 @@ class GetRecordsTests
 
       val withRecords = streams.findAndUpdateStream(streamName) { s =>
         s.copy(
-          shards = SortedMap(s.shards.head._1 -> records),
+          shards = Map(s.shards.head._1 -> records),
           streamStatus = StreamStatus.ACTIVE
         )
       }
@@ -173,8 +171,8 @@ class GetRecordsTests
         res = res1.flatMap(r1 => res2.map(r2 => (r1, r2)))
       } yield assert(
         res.isRight && res.exists { case (r1, r2) =>
-          r1.records === records
-            .take(50) && r2.records === records
+          r1.records.toVector === records
+            .take(50) && r2.records.toVector === records
             .takeRight(50)
         },
         s"res1Head: ${res.map { case (r1, _) => r1.records.head }.fold(_.toString, _.toString)}\n" +
@@ -202,8 +200,8 @@ class GetRecordsTests
 
       val shard = streams.streams(streamName).shards.head._1
 
-      val records: List[KinesisRecord] =
-        kinesisRecordArbitrary.arbitrary.take(50).toList.zipWithIndex.map {
+      val records: Vector[KinesisRecord] =
+        kinesisRecordArbitrary.arbitrary.take(50).toVector.zipWithIndex.map {
           case (record, index) =>
             record.copy(sequenceNumber =
               SequenceNumber.create(
@@ -218,7 +216,7 @@ class GetRecordsTests
 
       val withRecords = streams.findAndUpdateStream(streamName) { s =>
         s.copy(
-          shards = SortedMap(s.shards.head._1 -> records),
+          shards = Map(s.shards.head._1 -> records),
           streamStatus = StreamStatus.ACTIVE
         )
       }
@@ -242,7 +240,7 @@ class GetRecordsTests
         res = res1.flatMap(r1 => res2.map(r2 => (r1, r2)))
       } yield assert(
         res.isRight && res.exists { case (r1, r2) =>
-          r1.records === records
+          r1.records.toVector === records
             .take(50) && r2.records.isEmpty
         },
         s"res1Head: ${res.map { case (r1, _) => r1.records.head }.fold(_.toString, _.toString)}\n" +

--- a/src/test/scala/kinesis/mock/api/GetShardIteratorTests.scala
+++ b/src/test/scala/kinesis/mock/api/GetShardIteratorTests.scala
@@ -1,8 +1,6 @@
 package kinesis.mock
 package api
 
-import scala.collection.SortedMap
-
 import java.time.Instant
 
 import cats.effect.IO
@@ -28,8 +26,8 @@ class GetShardIteratorTests
 
       val shard = streams.streams(streamName).shards.head._1
 
-      val records: List[KinesisRecord] =
-        kinesisRecordArbitrary.arbitrary.take(50).toList.zipWithIndex.map {
+      val records: Vector[KinesisRecord] =
+        kinesisRecordArbitrary.arbitrary.take(50).toVector.zipWithIndex.map {
           case (record, index) =>
             record.copy(sequenceNumber =
               SequenceNumber.create(
@@ -44,7 +42,7 @@ class GetShardIteratorTests
 
       val withRecords = streams.findAndUpdateStream(streamName) { s =>
         s.copy(
-          shards = SortedMap(s.shards.head._1 -> records),
+          shards = Map(s.shards.head._1 -> records),
           streamStatus = StreamStatus.ACTIVE
         )
       }
@@ -81,8 +79,8 @@ class GetShardIteratorTests
 
       val shard = streams.streams(streamName).shards.head._1
 
-      val records: List[KinesisRecord] =
-        kinesisRecordArbitrary.arbitrary.take(50).toList.zipWithIndex.map {
+      val records: Vector[KinesisRecord] =
+        kinesisRecordArbitrary.arbitrary.take(50).toVector.zipWithIndex.map {
           case (record, index) =>
             record.copy(sequenceNumber =
               SequenceNumber.create(
@@ -97,7 +95,7 @@ class GetShardIteratorTests
 
       val withRecords = streams.findAndUpdateStream(streamName) { s =>
         s.copy(
-          shards = SortedMap(s.shards.head._1 -> records),
+          shards = Map(s.shards.head._1 -> records),
           streamStatus = StreamStatus.ACTIVE
         )
       }
@@ -136,8 +134,8 @@ class GetShardIteratorTests
 
       val startingInstant = Instant.parse("2021-01-01T00:00:00.00Z")
 
-      val records: List[KinesisRecord] =
-        kinesisRecordArbitrary.arbitrary.take(50).toList.zipWithIndex.map {
+      val records: Vector[KinesisRecord] =
+        kinesisRecordArbitrary.arbitrary.take(50).toVector.zipWithIndex.map {
           case (record, index) =>
             val newTimestamp = startingInstant.plusSeconds(index.toLong)
             record.copy(
@@ -154,7 +152,7 @@ class GetShardIteratorTests
 
       val withRecords = streams.findAndUpdateStream(streamName) { s =>
         s.copy(
-          shards = SortedMap(s.shards.head._1 -> records),
+          shards = Map(s.shards.head._1 -> records),
           streamStatus = StreamStatus.ACTIVE
         )
       }
@@ -195,8 +193,8 @@ class GetShardIteratorTests
 
       val shard = streams.streams(streamName).shards.head._1
 
-      val records: List[KinesisRecord] =
-        kinesisRecordArbitrary.arbitrary.take(50).toList.zipWithIndex.map {
+      val records: Vector[KinesisRecord] =
+        kinesisRecordArbitrary.arbitrary.take(50).toVector.zipWithIndex.map {
           case (record, index) =>
             record.copy(sequenceNumber =
               SequenceNumber.create(
@@ -211,7 +209,7 @@ class GetShardIteratorTests
 
       val withRecords = streams.findAndUpdateStream(streamName) { s =>
         s.copy(
-          shards = SortedMap(s.shards.head._1 -> records),
+          shards = Map(s.shards.head._1 -> records),
           streamStatus = StreamStatus.ACTIVE
         )
       }
@@ -250,8 +248,8 @@ class GetShardIteratorTests
 
       val shard = streams.streams(streamName).shards.head._1
 
-      val records: List[KinesisRecord] =
-        kinesisRecordArbitrary.arbitrary.take(50).toList.zipWithIndex.map {
+      val records: Vector[KinesisRecord] =
+        kinesisRecordArbitrary.arbitrary.take(50).toVector.zipWithIndex.map {
           case (record, index) =>
             record.copy(sequenceNumber =
               SequenceNumber.create(
@@ -266,7 +264,7 @@ class GetShardIteratorTests
 
       val withRecords = streams.findAndUpdateStream(streamName) { s =>
         s.copy(
-          shards = SortedMap(s.shards.head._1 -> records),
+          shards = Map(s.shards.head._1 -> records),
           streamStatus = StreamStatus.ACTIVE
         )
       }
@@ -304,8 +302,8 @@ class GetShardIteratorTests
 
         val shard = streams.streams(streamName).shards.head._1
 
-        val records: List[KinesisRecord] =
-          kinesisRecordArbitrary.arbitrary.take(50).toList.zipWithIndex.map {
+        val records: Vector[KinesisRecord] =
+          kinesisRecordArbitrary.arbitrary.take(50).toVector.zipWithIndex.map {
             case (record, index) =>
               record.copy(sequenceNumber =
                 SequenceNumber.create(
@@ -320,7 +318,7 @@ class GetShardIteratorTests
 
         val withRecords = streams.findAndUpdateStream(streamName) { s =>
           s.copy(
-            shards = SortedMap(s.shards.head._1 -> records),
+            shards = Map(s.shards.head._1 -> records),
             streamStatus = StreamStatus.ACTIVE
           )
         }
@@ -361,8 +359,8 @@ class GetShardIteratorTests
 
         val shard = streams.streams(streamName).shards.head._1
 
-        val records: List[KinesisRecord] =
-          kinesisRecordArbitrary.arbitrary.take(50).toList.zipWithIndex.map {
+        val records: Vector[KinesisRecord] =
+          kinesisRecordArbitrary.arbitrary.take(50).toVector.zipWithIndex.map {
             case (record, index) =>
               record.copy(sequenceNumber =
                 SequenceNumber.create(
@@ -377,7 +375,7 @@ class GetShardIteratorTests
 
         val withRecords = streams.findAndUpdateStream(streamName) { s =>
           s.copy(
-            shards = SortedMap(s.shards.head._1 -> records),
+            shards = Map(s.shards.head._1 -> records),
             streamStatus = StreamStatus.ACTIVE
           )
         }

--- a/src/test/scala/kinesis/mock/api/ListStreamConsumersTests.scala
+++ b/src/test/scala/kinesis/mock/api/ListStreamConsumersTests.scala
@@ -1,8 +1,6 @@
 package kinesis.mock
 package api
 
-import scala.collection.SortedMap
-
 import cats.effect.IO
 import cats.effect.concurrent.Ref
 import cats.syntax.all._
@@ -26,7 +24,7 @@ class ListStreamConsumersTests
       val streams =
         Streams.empty.addStream(100, streamName, awsRegion, awsAccountId)
 
-      val consumers = SortedMap.from(
+      val consumers = Map.from(
         Gen
           .listOfN(5, consumerArbitrary.arbitrary)
           .suchThat(x =>
@@ -51,7 +49,7 @@ class ListStreamConsumersTests
 
       } yield assert(
         res.isRight && res.exists { response =>
-          consumers.values.toList
+          consumers.values.toVector
             .map(ConsumerSummary.fromConsumer) === response.consumers
         },
         s"req: $req\nres: $res"
@@ -89,7 +87,7 @@ class ListStreamConsumersTests
       val streams =
         Streams.empty.addStream(100, streamName, awsRegion, awsAccountId)
 
-      val consumers = SortedMap.from(
+      val consumers = Map.from(
         Gen
           .listOfN(10, consumerArbitrary.arbitrary)
           .suchThat(x =>
@@ -126,12 +124,12 @@ class ListStreamConsumersTests
         res.isRight && paginatedRes.isRight && res.exists { response =>
           consumers.values
             .take(5)
-            .toList
+            .toVector
             .map(ConsumerSummary.fromConsumer) === response.consumers
         } && paginatedRes.exists { response =>
           consumers.values
             .takeRight(5)
-            .toList
+            .toVector
             .map(ConsumerSummary.fromConsumer) === response.consumers
         },
         s"req: $req\n" +

--- a/src/test/scala/kinesis/mock/api/ListTagsForStreamTests.scala
+++ b/src/test/scala/kinesis/mock/api/ListTagsForStreamTests.scala
@@ -1,8 +1,6 @@
 package kinesis.mock
 package api
 
-import scala.collection.SortedMap
-
 import cats.effect.IO
 import cats.effect.concurrent.Ref
 import enumeratum.scalacheck._
@@ -52,11 +50,11 @@ class ListTagsForStreamTests
 
       val tags: Tags = Gen
         .mapOfN(10, Gen.zip(tagKeyGen, tagValueGen))
-        .map(x => SortedMap.from(x))
+        .map(x => Map.from(x))
         .map(Tags.apply)
         .one
 
-      val exclusiveStartTagKey = tags.tags.keys.toList(3)
+      val exclusiveStartTagKey = tags.tags.keys.toVector(3)
 
       val withTags =
         streams.findAndUpdateStream(streamName)(s => s.copy(tags = tags))
@@ -90,7 +88,7 @@ class ListTagsForStreamTests
 
       val tags: Tags = Gen
         .mapOfN(10, Gen.zip(tagKeyGen, tagValueGen))
-        .map(x => SortedMap.from(x))
+        .map(x => Map.from(x))
         .map(Tags.apply)
         .one
 

--- a/src/test/scala/kinesis/mock/api/MergeShardsTests.scala
+++ b/src/test/scala/kinesis/mock/api/MergeShardsTests.scala
@@ -24,10 +24,10 @@ class MergeShardsTests
         streams.findAndUpdateStream(streamName)(s =>
           s.copy(streamStatus = StreamStatus.ACTIVE)
         )
-      val shardToMerge =
-        active.streams(streamName).shards.keys.head
-      val adjacentShardToMerge =
-        active.streams(streamName).shards.keys.toList(1)
+      val shards = active.streams(streamName).shards.keys.toVector.sorted
+
+      val shardToMerge = shards.head
+      val adjacentShardToMerge = shards(1)
 
       for {
         streamsRef <- Ref.of[IO, Streams](active)
@@ -40,7 +40,7 @@ class MergeShardsTests
         s <- streamsRef.get
       } yield assert(
         res.isRight && s.streams.get(streamName).exists { stream =>
-          stream.shards.keys.toList.exists(shard =>
+          stream.shards.keys.toVector.exists(shard =>
             shard.adjacentParentShardId
               .contains(adjacentShardToMerge.shardId.shardId) &&
               shard.parentShardId.contains(shardToMerge.shardId.shardId)
@@ -62,10 +62,10 @@ class MergeShardsTests
       val streams =
         Streams.empty.addStream(5, streamName, awsRegion, awsAccountId)
 
-      val shardToMerge =
-        streams.streams(streamName).shards.keys.head
-      val adjacentShardToMerge =
-        streams.streams(streamName).shards.keys.toList(1)
+      val shards = streams.streams(streamName).shards.keys.toVector.sorted
+
+      val shardToMerge = shards.head
+      val adjacentShardToMerge = shards(1)
 
       val req =
         MergeShardsRequest(
@@ -94,18 +94,10 @@ class MergeShardsTests
       val active = streams.findAndUpdateStream(streamName)(s =>
         s.copy(streamStatus = StreamStatus.ACTIVE)
       )
-      val shardToMerge =
-        active.streams(streamName).shards.keys.head
+      val shards = active.streams(streamName).shards.keys.toVector.sorted
+      val shardToMerge = shards.head
       val adjacentShardToMerge =
-        ShardId.create(
-          active
-            .streams(streamName)
-            .shards
-            .keys
-            .toList
-            .map(_.shardId.index)
-            .max + 1
-        )
+        ShardId.create(shards.map(_.shardId.index).max + 1)
 
       val req =
         MergeShardsRequest(
@@ -134,18 +126,11 @@ class MergeShardsTests
       val active = streams.findAndUpdateStream(streamName)(s =>
         s.copy(streamStatus = StreamStatus.ACTIVE)
       )
+      val shards = active.streams(streamName).shards.keys.toVector.sorted
       val shardToMerge =
-        ShardId.create(
-          active
-            .streams(streamName)
-            .shards
-            .keys
-            .toList
-            .map(_.shardId.index)
-            .max + 1
-        )
-      val adjacentShardToMerge =
-        streams.streams(streamName).shards.keys.toList(1)
+        ShardId.create(shards.map(_.shardId.index).max + 1)
+
+      val adjacentShardToMerge = shards(1)
 
       val req =
         MergeShardsRequest(
@@ -174,10 +159,9 @@ class MergeShardsTests
       val active = streams.findAndUpdateStream(streamName)(s =>
         s.copy(streamStatus = StreamStatus.ACTIVE)
       )
-      val shardToMerge =
-        streams.streams(streamName).shards.keys.head
-      val adjacentShardToMerge =
-        streams.streams(streamName).shards.keys.toList(2)
+      val shards = streams.streams(streamName).shards.keys.toVector.sorted
+      val shardToMerge = shards.head
+      val adjacentShardToMerge = shards(2)
 
       val req =
         MergeShardsRequest(

--- a/src/test/scala/kinesis/mock/api/PutRecordTests.scala
+++ b/src/test/scala/kinesis/mock/api/PutRecordTests.scala
@@ -36,7 +36,7 @@ class PutRecordTests
         s <- streamsRef.get
       } yield assert(
         res.isRight && s.streams.get(streamName).exists { stream =>
-          stream.shards.values.toList.flatten.exists { rec =>
+          stream.shards.values.toVector.flatten.exists { rec =>
             rec.data.sameElements(initReq.data)
           }
         },

--- a/src/test/scala/kinesis/mock/api/PutRecordsTests.scala
+++ b/src/test/scala/kinesis/mock/api/PutRecordsTests.scala
@@ -36,7 +36,7 @@ class PutRecordsTests
         s <- streamsRef.get
       } yield assert(
         res.isRight && s.streams.get(streamName).exists { stream =>
-          stream.shards.values.toList.flatten.count { rec =>
+          stream.shards.values.toVector.flatten.count { rec =>
             req.records.map(_.data).exists(_.sameElements(rec.data))
           } == initReq.records.length
         },

--- a/src/test/scala/kinesis/mock/api/RegisterStreamConsumerTests.scala
+++ b/src/test/scala/kinesis/mock/api/RegisterStreamConsumerTests.scala
@@ -1,8 +1,6 @@
 package kinesis.mock
 package api
 
-import scala.collection.SortedMap
-
 import cats.effect.IO
 import cats.effect.concurrent.Ref
 import enumeratum.scalacheck._
@@ -51,7 +49,7 @@ class RegisterStreamConsumerTests
       val streams =
         Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
-      val consumers = SortedMap.from(
+      val consumers = Map.from(
         Gen
           .listOfN(20, consumerArbitrary.arbitrary)
           .suchThat(x =>
@@ -87,7 +85,7 @@ class RegisterStreamConsumerTests
         val streams =
           Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
-        val consumers = SortedMap.from(
+        val consumers = Map.from(
           Gen
             .listOfN(5, consumerArbitrary.arbitrary)
             .suchThat(x =>

--- a/src/test/scala/kinesis/mock/api/RemoveTagsFromStreamTests.scala
+++ b/src/test/scala/kinesis/mock/api/RemoveTagsFromStreamTests.scala
@@ -1,8 +1,6 @@
 package kinesis.mock
 package api
 
-import scala.collection.SortedMap
-
 import cats.effect.IO
 import cats.effect.concurrent.Ref
 import enumeratum.scalacheck._
@@ -27,14 +25,14 @@ class RemoveTagsFromStreamTests
 
       val tags: Tags = Gen
         .mapOfN(10, Gen.zip(tagKeyGen, tagValueGen))
-        .map(x => SortedMap.from(x))
+        .map(x => Map.from(x))
         .map(Tags.apply)
         .one
 
       val withTags =
         streams.findAndUpdateStream(streamName)(_.copy(tags = tags))
 
-      val removedTags = tags.tags.keys.take(3).toList
+      val removedTags = tags.tags.keys.take(3).toVector
 
       for {
         streamsRef <- Ref.of[IO, Streams](withTags)

--- a/src/test/scala/kinesis/mock/api/SplitShardTests.scala
+++ b/src/test/scala/kinesis/mock/api/SplitShardTests.scala
@@ -50,7 +50,7 @@ class SplitShardTests
         s <- streamsRef.get
       } yield assert(
         res.isRight && s.streams.get(streamName).exists { stream =>
-          stream.shards.keys.toList.count(shard =>
+          stream.shards.keys.toVector.count(shard =>
             shard.parentShardId.contains(shardToSplit.shardId.shardId)
           ) == 2 && stream.streamStatus == StreamStatus.UPDATING
         },
@@ -109,7 +109,7 @@ class SplitShardTests
             .streams(streamName)
             .shards
             .keys
-            .toList
+            .toVector
             .map(_.shardId.index)
             .max + 1
         )

--- a/src/test/scala/kinesis/mock/api/UpdateShardCountTests.scala
+++ b/src/test/scala/kinesis/mock/api/UpdateShardCountTests.scala
@@ -38,20 +38,21 @@ class UpdateShardCountTests
         s <- streamsRef.get
       } yield assert(
         res.isRight && s.streams.get(streamName).exists { stream =>
-          val shards = stream.shards.keys.toList
+          val shards = stream.shards.keys.toVector.sorted
           shards.count(_.isOpen) == 10 &&
           shards.filterNot(_.isOpen).map(_.shardId) == active
             .streams(streamName)
             .shards
             .keys
-            .toList
+            .toVector
+            .sorted
             .map(_.shardId) &&
           stream.streamStatus == StreamStatus.UPDATING
         },
         s"req: $req\n" +
-          s"resOpenShards: ${s.streams(streamName).shards.keys.toList.filter(_.isOpen).map(_.shardId)}\n" +
-          s"resClosedShards: ${s.streams(streamName).shards.keys.toList.filterNot(_.isOpen).map(_.shardId)}\n" +
-          s"inputShards: ${active.streams(streamName).shards.keys.toList.map(_.shardId)}"
+          s"resOpenShards: ${s.streams(streamName).shards.keys.toVector.filter(_.isOpen).map(_.shardId)}\n" +
+          s"resClosedShards: ${s.streams(streamName).shards.keys.toVector.filterNot(_.isOpen).map(_.shardId)}\n" +
+          s"inputShards: ${active.streams(streamName).shards.keys.toVector.map(_.shardId)}"
       )
   })
 
@@ -81,20 +82,21 @@ class UpdateShardCountTests
         s <- streamsRef.get
       } yield assert(
         res.isRight && s.streams.get(streamName).exists { stream =>
-          val shards = stream.shards.keys.toList
+          val shards = stream.shards.keys.toVector.sorted
           shards.count(_.isOpen) == 5 &&
           shards.filterNot(_.isOpen).map(_.shardId) == active
             .streams(streamName)
             .shards
             .keys
-            .toList
+            .toVector
+            .sorted
             .map(_.shardId) &&
           stream.streamStatus == StreamStatus.UPDATING
         },
         s"req: $req\n" +
-          s"resOpenShards: ${s.streams(streamName).shards.keys.toList.filter(_.isOpen).map(_.shardId)}\n" +
-          s"resClosedShards: ${s.streams(streamName).shards.keys.toList.filterNot(_.isOpen).map(_.shardId)}\n" +
-          s"inputShards: ${active.streams(streamName).shards.keys.toList.map(_.shardId)}"
+          s"resOpenShards: ${s.streams(streamName).shards.keys.toVector.filter(_.isOpen).map(_.shardId)}\n" +
+          s"resClosedShards: ${s.streams(streamName).shards.keys.toVector.filterNot(_.isOpen).map(_.shardId)}\n" +
+          s"inputShards: ${active.streams(streamName).shards.keys.toVector.map(_.shardId)}"
       )
   })
 

--- a/src/test/scala/kinesis/mock/cache/CacheConfigTests.scala
+++ b/src/test/scala/kinesis/mock/cache/CacheConfigTests.scala
@@ -23,7 +23,7 @@ class CacheConfigTests
       val res = CacheConfig.initializeStreamsReader.from(
         ConfigValueFactory.fromAnyRef(s"$streamName:3")
       )
-      val expected = List(
+      val expected = Vector(
         CreateStreamRequest(3, streamName)
       )
 
@@ -43,7 +43,7 @@ class CacheConfigTests
           s"$streamName1:3,$streamName2:2,$streamName3:1"
         )
       )
-      val expected = List(
+      val expected = Vector(
         CreateStreamRequest(3, streamName1),
         CreateStreamRequest(2, streamName2),
         CreateStreamRequest(1, streamName3)
@@ -89,7 +89,7 @@ class CacheConfigTests
           streamName1: StreamName,
           streamName2: StreamName
       ) =>
-        val res = List(
+        val res = Vector(
           CacheConfig.initializeStreamsReader.from(
             ConfigValueFactory.fromAnyRef(s":$streamName1")
           ),

--- a/src/test/scala/kinesis/mock/cache/DescribeStreamSummaryTests.scala
+++ b/src/test/scala/kinesis/mock/cache/DescribeStreamSummaryTests.scala
@@ -39,7 +39,7 @@ class DescribeStreamSummaryTests
           expected = StreamDescriptionSummary(
             Some(0),
             Some(EncryptionType.NONE),
-            List(ShardLevelMetrics(List.empty)),
+            Vector(ShardLevelMetrics(Vector.empty)),
             None,
             1,
             24,

--- a/src/test/scala/kinesis/mock/cache/DescribeStreamTests.scala
+++ b/src/test/scala/kinesis/mock/cache/DescribeStreamTests.scala
@@ -53,7 +53,7 @@ class DescribeStreamTests
             .map(x => x.shards)
           expected = StreamDescription(
             Some(EncryptionType.NONE),
-            List(ShardLevelMetrics(List.empty)),
+            Vector(ShardLevelMetrics(Vector.empty)),
             false,
             None,
             24,

--- a/src/test/scala/kinesis/mock/cache/DisableEnhancedMonitoringTests.scala
+++ b/src/test/scala/kinesis/mock/cache/DisableEnhancedMonitoringTests.scala
@@ -32,7 +32,7 @@ class DisableEnhancedMonitoringTests
           _ <- cache
             .enableEnhancedMonitoring(
               EnableEnhancedMonitoringRequest(
-                List(ShardLevelMetric.ALL),
+                Vector(ShardLevelMetric.ALL),
                 streamName
               ),
               context,
@@ -42,7 +42,7 @@ class DisableEnhancedMonitoringTests
           res <- cache
             .disableEnhancedMonitoring(
               DisableEnhancedMonitoringRequest(
-                List(ShardLevelMetric.IncomingBytes),
+                Vector(ShardLevelMetric.IncomingBytes),
                 streamName
               ),
               context,

--- a/src/test/scala/kinesis/mock/cache/EnableEnhancedMonitoringTests.scala
+++ b/src/test/scala/kinesis/mock/cache/EnableEnhancedMonitoringTests.scala
@@ -32,7 +32,7 @@ class EnableEnhancedMonitoringTests
           res <- cache
             .enableEnhancedMonitoring(
               EnableEnhancedMonitoringRequest(
-                List(ShardLevelMetric.IncomingBytes),
+                Vector(ShardLevelMetric.IncomingBytes),
                 streamName
               ),
               context,

--- a/src/test/scala/kinesis/mock/cache/GetRecordsTests.scala
+++ b/src/test/scala/kinesis/mock/cache/GetRecordsTests.scala
@@ -36,7 +36,7 @@ class GetRecordsTests
           recordRequests <- IO(
             putRecordRequestArb.arbitrary
               .take(5)
-              .toList
+              .toVector
               .map(_.copy(streamName = streamName))
           )
           _ <- recordRequests.traverse(req =>

--- a/src/test/scala/kinesis/mock/cache/ListStreamConsumersTests.scala
+++ b/src/test/scala/kinesis/mock/cache/ListStreamConsumersTests.scala
@@ -51,7 +51,7 @@ class ListStreamConsumersTests
               )
               .one
           )
-          registerResults <- consumerNames.toList.traverse(consumerName =>
+          registerResults <- consumerNames.toVector.traverse(consumerName =>
             cache
               .registerStreamConsumer(
                 RegisterStreamConsumerRequest(consumerName, streamArn),

--- a/src/test/scala/kinesis/mock/cache/PersistenceTests.scala
+++ b/src/test/scala/kinesis/mock/cache/PersistenceTests.scala
@@ -50,7 +50,7 @@ class PersistenceTests
           recordRequests <- IO(
             putRecordRequestArb.arbitrary
               .take(5)
-              .toList
+              .toVector
               .map(_.copy(streamName = streamName))
           )
           _ <- recordRequests.traverse(req =>

--- a/src/test/scala/kinesis/mock/cache/PutRecordTests.scala
+++ b/src/test/scala/kinesis/mock/cache/PutRecordTests.scala
@@ -36,7 +36,7 @@ class PutRecordTests
           recordRequests <- IO(
             putRecordRequestArb.arbitrary
               .take(5)
-              .toList
+              .toVector
               .map(_.copy(streamName = streamName))
           )
           _ <- recordRequests.traverse(req =>

--- a/src/test/scala/kinesis/mock/cache/PutRecordsTests.scala
+++ b/src/test/scala/kinesis/mock/cache/PutRecordsTests.scala
@@ -37,7 +37,7 @@ class PutRecordsTests
             PutRecordsRequest(
               putRecordsRequestEntryArb.arbitrary
                 .take(5)
-                .toList,
+                .toVector,
               streamName
             )
           )

--- a/src/test/scala/kinesis/mock/cache/RemoveTagsFromStreamTests.scala
+++ b/src/test/scala/kinesis/mock/cache/RemoveTagsFromStreamTests.scala
@@ -38,7 +38,7 @@ class RemoveTagsFromStreamTests
             )
             .rethrow
           _ <- cache.removeTagsFromStream(
-            RemoveTagsFromStreamRequest(streamName, tags.tags.keys.toList),
+            RemoveTagsFromStreamRequest(streamName, tags.tags.keys.toVector),
             context,
             false
           )

--- a/src/test/scala/kinesis/mock/instances/arbitrary.scala
+++ b/src/test/scala/kinesis/mock/instances/arbitrary.scala
@@ -1,6 +1,6 @@
 package kinesis.mock.instances
 
-import scala.collection.SortedMap
+import scala.collection.immutable.Queue
 import scala.concurrent.duration._
 
 import java.time.Instant
@@ -163,7 +163,7 @@ object arbitrary {
             ShardLevelMetric.IteratorAgeMilliseconds
           )
         )
-        .map(x => ShardLevelMetrics(x.toList))
+        .map(x => ShardLevelMetrics(x.toVector))
     )
 
   def shardGen(shardIndex: Int): Gen[Shard] = for {
@@ -214,7 +214,7 @@ object arbitrary {
   val tagsGen: Gen[Tags] = Gen
     .choose(0, 10)
     .flatMap(size => Gen.mapOfN(size, Gen.zip(tagKeyGen, tagValueGen)))
-    .map(x => SortedMap.from(x))
+    .map(x => Map.from(x))
     .map(Tags.apply)
 
   implicit val tagListArb: Arbitrary[TagList] = Arbitrary(
@@ -335,7 +335,10 @@ object arbitrary {
       enhancedMonitoring <- Gen
         .choose(0, 1)
         .flatMap(size =>
-          Gen.listOfN(size, shardLevelMetricsArbitrary.arbitrary)
+          Gen.containerOfN[Vector, ShardLevelMetrics](
+            size,
+            shardLevelMetricsArbitrary.arbitrary
+          )
         )
       hasMoreShards <- Arbitrary.arbitrary[Boolean]
       keyId <- Gen.option(keyIdGen)
@@ -344,7 +347,7 @@ object arbitrary {
       shardGens = List
         .range(1, shardCount)
         .map(index => shardGen(index).map(ShardSummary.fromShard))
-      shards <- Gen.sequence[List[ShardSummary], ShardSummary](shardGens)
+      shards <- Gen.sequence[Vector[ShardSummary], ShardSummary](shardGens)
       streamCreationTimestamp <- nowGen
       streamName <- streamNameGen
       streamArn <- arnGen("kinesis", "stream", streamName.streamName)
@@ -396,7 +399,10 @@ object arbitrary {
       enhancedMonitoring <- Gen
         .choose(0, 1)
         .flatMap(size =>
-          Gen.listOfN(size, shardLevelMetricsArbitrary.arbitrary)
+          Gen.containerOfN[Vector, ShardLevelMetrics](
+            size,
+            shardLevelMetricsArbitrary.arbitrary
+          )
         )
       keyId <- Gen.option(keyIdGen)
       openShardCount <- Gen.choose(1, 50)
@@ -496,19 +502,22 @@ object arbitrary {
   val childShardGen: Gen[ChildShard] = for {
     shardIndex <- Gen.choose(100, 1000)
     shardId = ShardId.create(shardIndex).shardId
-    parentShards = List.range(0, shardIndex).map(ShardId.create).map(_.shardId)
+    parentShards = Vector
+      .range(0, shardIndex)
+      .map(ShardId.create)
+      .map(_.shardId)
     hashKeyRange <- hashKeyRangeArbitrary.arbitrary
   } yield ChildShard(hashKeyRange, parentShards, shardId)
 
   implicit val getRecordsResponseArb: Arbitrary[GetRecordsResponse] = Arbitrary(
     for {
-      childShards <- Gen.listOf(childShardGen)
+      childShards <- Gen.containerOf[Vector, ChildShard](childShardGen)
       millisBehindLatest <- Gen.choose(0L, 1.day.toMillis)
       nextShardIterator <- shardIteratorGen
       records <- Gen
         .choose(0, 100)
         .flatMap(size =>
-          Gen.listOfN(
+          Gen.containerOfN[Queue, KinesisRecord](
             size,
             kinesisRecordArbitrary.arbitrary
           )
@@ -618,8 +627,8 @@ object arbitrary {
   implicit val listShardsResponseArb: Arbitrary[ListShardsResponse] = Arbitrary(
     for {
       nextToken <- Gen.option(nextTokenGen(None))
-      shards <- Gen.sequence[List[ShardSummary], ShardSummary](
-        List.range(0, 100).map(x => shardSummaryGen(x))
+      shards <- Gen.sequence[Vector[ShardSummary], ShardSummary](
+        Vector.range(0, 100).map(x => shardSummaryGen(x))
       )
     } yield ListShardsResponse(nextToken, shards)
   )
@@ -643,7 +652,10 @@ object arbitrary {
       : Arbitrary[ListStreamConsumersResponse] = Arbitrary(
     for {
       size <- Gen.choose(0, 20)
-      consumers <- Gen.listOfN(size, consumerSummaryArb.arbitrary)
+      consumers <- Gen.containerOfN[Vector, ConsumerSummary](
+        size,
+        consumerSummaryArb.arbitrary
+      )
       nextToken = consumers.lastOption.map(_.consumerName)
     } yield ListStreamConsumersResponse(consumers, nextToken)
   )
@@ -660,7 +672,7 @@ object arbitrary {
       for {
         hasMoreStreams <- Arbitrary.arbitrary[Boolean]
         size <- Gen.choose(0, 50)
-        streamNames <- Gen.listOfN(size, streamNameGen)
+        streamNames <- Gen.containerOfN[Vector, StreamName](size, streamNameGen)
       } yield ListStreamsResponse(hasMoreStreams, streamNames)
     )
 
@@ -736,7 +748,10 @@ object arbitrary {
   implicit val putRecordsRequestArb: Arbitrary[PutRecordsRequest] = Arbitrary(
     for {
       recordsSize <- Gen.choose(0, 500)
-      records <- Gen.listOfN(recordsSize, putRecordsRequestEntryArb.arbitrary)
+      records <- Gen.containerOfN[Vector, PutRecordsRequestEntry](
+        recordsSize,
+        putRecordsRequestEntryArb.arbitrary
+      )
       streamName <- streamNameGen
     } yield PutRecordsRequest(records, streamName)
   )
@@ -770,7 +785,10 @@ object arbitrary {
       encryptionType <- Arbitrary.arbitrary[EncryptionType]
       failedRecordCount <- Gen.choose(0, 500)
       recordsSize <- Gen.choose(failedRecordCount, 500)
-      records <- Gen.listOfN(recordsSize, putRecordsResultEntry.arbitrary)
+      records <- Gen.containerOfN[Vector, PutRecordsResultEntry](
+        recordsSize,
+        putRecordsResultEntry.arbitrary
+      )
     } yield PutRecordsResponse(encryptionType, failedRecordCount, records)
   )
 
@@ -836,27 +854,34 @@ object arbitrary {
           consumersSize,
           consumerArbitrary.arbitrary.map(x => x.consumerName -> x)
         )
-        .map(x => SortedMap.from(x))
+        .map(x => Map.from(x))
       encryptionType <- Arbitrary.arbitrary[EncryptionType]
       enhancedMonitoring <- Gen
         .choose(0, 1)
         .flatMap(size =>
-          Gen.listOfN(size, shardLevelMetricsArbitrary.arbitrary)
+          Gen.containerOfN[Vector, ShardLevelMetrics](
+            size,
+            shardLevelMetricsArbitrary.arbitrary
+          )
         )
       keyId <- Gen.option(keyIdGen)
       retentionPeriod <- retentionPeriodHoursGen.map(_.hours)
       shardsSize <- Gen.choose(0, 50)
-      shardList <- Gen.listOfN(shardsSize, shardArbitrary.arbitrary)
-      shards <- Gen.sequence[SortedMap[
+      shardList <- Gen
+        .containerOfN[Vector, Shard](shardsSize, shardArbitrary.arbitrary)
+      shards <- Gen.sequence[Map[
         Shard,
-        List[KinesisRecord]
-      ], (Shard, List[KinesisRecord])](
+        Vector[KinesisRecord]
+      ], (Shard, Vector[KinesisRecord])](
         shardList.map(shard =>
           Gen
             .choose(0, 100)
             .flatMap(recordsSize =>
               Gen
-                .listOfN(recordsSize, kinesisRecordArbitrary.arbitrary)
+                .containerOfN[Vector, KinesisRecord](
+                  recordsSize,
+                  kinesisRecordArbitrary.arbitrary
+                )
                 .map(records => shard -> records)
             )
         )
@@ -868,7 +893,7 @@ object arbitrary {
       tags <- tagsGen
       shardCountUpdates <- Gen
         .choose(0, 10)
-        .flatMap(size => Gen.listOfN(size, nowGen))
+        .flatMap(size => Gen.containerOfN[Vector, Instant](size, nowGen))
     } yield StreamData(
       consumers,
       encryptionType,
@@ -892,7 +917,7 @@ object arbitrary {
       .suchThat(x =>
         x.groupBy(_.streamName).filter { case (_, x) => x.length > 1 }.isEmpty
       )
-      .map(x => Streams(SortedMap.from(x.map(sd => sd.streamName -> sd))))
+      .map(x => Streams(Map.from(x.map(sd => sd.streamName -> sd))))
   }
 
 }


### PR DESCRIPTION
## Changes Introduced

The mock used both SortedMap and List everywhere, which aren't as performant for the operations being called on it. 

For instance, a List was being used to store the KinesisRecords, which would have appends to the data. Appending to a list is extremely inefficient. In terms of SortedMap, there were only a few API calls that really required the sorting (list* APIs), so the overhead of keeping the Map sorted was moved there.

## Applicable linked issues

N/A

## Checklist (check all that apply)

- [x] This change maintains backwards compatibility
- [ ] I have introduced tests for all new features and changes
- [ ] I have added documentation covering all new features and changes
- [x] This pull-request is ready for review