### PR TITLE
DescribeStream functional tests now run the correct API call

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,8 +1,7 @@
 <configuration>
-  <property name="timestamp" value="yyyy-MM-dd HH:mm:ss" />
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>[%thread] %highlight(%-5level) %d{${timestamp}} %cyan(%logger{15}) %yellow(%mdc) - %msg %n</pattern>
+      <pattern>[%thread] %highlight(%-5level) %d{ISO8601} %cyan(%logger{15}) %yellow(%mdc) - %msg %n</pattern>
     </encoder>
   </appender>
   <logger name="kinesis.mock" level="${LOG_LEVEL:-INFO}"/>


### PR DESCRIPTION
## Changes Introduced

The DescribeStream functional tests were running DescribeStreamSummary rather than DescribeStream. Updated to fix this.

## Applicable linked issues

N/A

## Checklist (check all that apply)

- [ ] This change maintains backwards compatibility
- [ ] I have introduced tests for all new features and changes
- [ ] I have added documentation covering all new features and changes
- [X] This pull-request is ready for review