### PR TITLE
Update max string length for tag values from 255 to 256

### DIFF
--- a/src/main/scala/kinesis/mock/api/AddTagsToStreamRequest.scala
+++ b/src/main/scala/kinesis/mock/api/AddTagsToStreamRequest.scala
@@ -29,10 +29,10 @@ final case class AddTagsToStreamRequest(
             (
               CommonValidations.validateTagKeys(tags.tags.keys), {
                 val valuesTooLong =
-                  tags.tags.values.filter(x => x.length() > 255)
+                  tags.tags.values.filter(x => x.length() > 256)
                 if (valuesTooLong.nonEmpty)
                   InvalidArgumentException(
-                    s"Values must be less than 255 characters. Invalid values: ${valuesTooLong.mkString(", ")}"
+                    s"Values must be less than 256 characters. Invalid values: ${valuesTooLong.mkString(", ")}"
                   ).asLeft
                 else Right(())
               }, {

--- a/src/test/scala/kinesis/mock/instances/arbitrary.scala
+++ b/src/test/scala/kinesis/mock/instances/arbitrary.scala
@@ -206,7 +206,7 @@ object arbitrary {
     )
 
   val tagValueGen: Gen[String] = Gen
-    .choose(0, 255)
+    .choose(0, 256)
     .flatMap(size =>
       Gen.resize(size, RegexpGen.from("^([a-zA-Z0-9_.:/=+\\-]*)$"))
     )


### PR DESCRIPTION
## Changes Introduced

Update max string length for tag values from 255 to 256 - see docs here: https://docs.aws.amazon.com/kinesis/latest/APIReference/API_Tag.html

This is currently breaking some Terraform tests we're running against LocalStack. 

Thanks!

## Checklist (check all that apply)

- [x] This change maintains backwards compatibility
- [ ] I have introduced tests for all new features and changes
- [ ] I have added documentation covering all new features and changes
- [x] This pull-request is ready for review
