### PR TITLE
Fix bug in enforceConsumerDeletion

### DIFF
--- a/src/fun/scala/kinesis/mock/AwsFunctionalTests.scala
+++ b/src/fun/scala/kinesis/mock/AwsFunctionalTests.scala
@@ -115,6 +115,7 @@ trait AwsFunctionalTests extends CatsEffectFunFixtures { _: CatsEffectSuite =>
         DeleteStreamRequest
           .builder()
           .streamName(resources.streamName.streamName)
+          .enforceConsumerDeletion(true)
           .build()
       )
       .toIO

--- a/src/main/scala/kinesis/mock/api/DeleteStreamRequest.scala
+++ b/src/main/scala/kinesis/mock/api/DeleteStreamRequest.scala
@@ -27,7 +27,8 @@ final case class DeleteStreamRequest(
               (
                 CommonValidations.isStreamActive(streamName, streams),
                 if (
-                  !enforceConsumerDeletion.getOrElse(false) && stream.consumers.nonEmpty
+                  !enforceConsumerDeletion
+                    .getOrElse(false) && stream.consumers.nonEmpty
                 )
                   ResourceInUseException(
                     s"Consumers exist in stream $streamName and enforceConsumerDeletion is either not set or is false"

--- a/src/main/scala/kinesis/mock/api/DeleteStreamRequest.scala
+++ b/src/main/scala/kinesis/mock/api/DeleteStreamRequest.scala
@@ -27,11 +27,10 @@ final case class DeleteStreamRequest(
               (
                 CommonValidations.isStreamActive(streamName, streams),
                 if (
-                  enforceConsumerDeletion
-                    .exists(identity) && stream.consumers.nonEmpty
+                  !enforceConsumerDeletion.getOrElse(false) && stream.consumers.nonEmpty
                 )
                   ResourceInUseException(
-                    s"Consumers exist in stream $streamName and enforceConsumerDeletion is true"
+                    s"Consumers exist in stream $streamName and enforceConsumerDeletion is either not set or is false"
                   ).asLeft
                 else Right(())
               ).mapN((_, _) => stream)

--- a/src/test/scala/kinesis/mock/api/DeleteStreamTests.scala
+++ b/src/test/scala/kinesis/mock/api/DeleteStreamTests.scala
@@ -83,8 +83,9 @@ class DeleteStreamTests
         Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
       val withConsumers = streams.findAndUpdateStream(streamName)(x =>
-        x.copy(consumers =
-          Map(consumerName -> Consumer.create(x.streamArn, consumerName)),
+        x.copy(
+          consumers =
+            Map(consumerName -> Consumer.create(x.streamArn, consumerName)),
           streamStatus = StreamStatus.ACTIVE
         )
       )
@@ -92,6 +93,36 @@ class DeleteStreamTests
       for {
         streamsRef <- Ref.of[IO, Streams](withConsumers)
         req = DeleteStreamRequest(streamName, None)
+        res <- req.deleteStream(streamsRef)
+      } yield assert(
+        res.isLeft,
+        s"req: $req\nres: $res\nstreams: $streams"
+      )
+  })
+
+  test(
+    "It should reject when the stream has consumes and enforceConsumerDeletion is false"
+  )(PropF.forAllF {
+    (
+        streamName: StreamName,
+        awsRegion: AwsRegion,
+        awsAccountId: AwsAccountId,
+        consumerName: ConsumerName
+    ) =>
+      val streams =
+        Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
+
+      val withConsumers = streams.findAndUpdateStream(streamName)(x =>
+        x.copy(
+          consumers =
+            Map(consumerName -> Consumer.create(x.streamArn, consumerName)),
+          streamStatus = StreamStatus.ACTIVE
+        )
+      )
+
+      for {
+        streamsRef <- Ref.of[IO, Streams](withConsumers)
+        req = DeleteStreamRequest(streamName, Some(false))
         res <- req.deleteStream(streamsRef)
       } yield assert(
         res.isLeft,

--- a/src/test/scala/kinesis/mock/api/DeleteStreamTests.scala
+++ b/src/test/scala/kinesis/mock/api/DeleteStreamTests.scala
@@ -71,7 +71,7 @@ class DeleteStreamTests
   })
 
   test(
-    "It should reject when the stream has consumes and enforceConsumerDeletion is true"
+    "It should reject when the stream has consumes and enforceConsumerDeletion is not set"
   )(PropF.forAllF {
     (
         streamName: StreamName,
@@ -84,7 +84,8 @@ class DeleteStreamTests
 
       val withConsumers = streams.findAndUpdateStream(streamName)(x =>
         x.copy(consumers =
-          Map(consumerName -> Consumer.create(x.streamArn, consumerName))
+          Map(consumerName -> Consumer.create(x.streamArn, consumerName)),
+          streamStatus = StreamStatus.ACTIVE
         )
       )
 


### PR DESCRIPTION
## Changes Introduced

The logic on enforceConsumerDeletion was backwards. This resolves that issue.

## Applicable linked issues

#120 

## Checklist (check all that apply)

- [x] This change maintains backwards compatibility
- [ ] I have introduced tests for all new features and changes
- [ ] I have added documentation covering all new features and changes
- [x] This pull-request is ready for review