### PR TITLE
Use IOApp EC for Blaze

### DIFF
--- a/src/main/scala/kinesis/mock/KinesisMockService.scala
+++ b/src/main/scala/kinesis/mock/KinesisMockService.scala
@@ -50,7 +50,7 @@ object KinesisMockService extends IOApp {
           serviceConfig.keyStorePassword,
           serviceConfig.keyManagerPassword
         )
-        http2Server = BlazeServerBuilder[IO](ExecutionContext.global)
+        http2Server = BlazeServerBuilder[IO](executionContext)
           .bindHttp(serviceConfig.tlsPort, "0.0.0.0")
           .withHttpApp(app)
           .withSslContext(context)
@@ -58,7 +58,7 @@ object KinesisMockService extends IOApp {
             true
           ) // This is bugged and HTTP2 unfortunately does not work correctly right now
           .resource
-        http1PlainServer = BlazeServerBuilder[IO](ExecutionContext.global)
+        http1PlainServer = BlazeServerBuilder[IO](executionContext)
           .bindHttp(serviceConfig.plainPort, "0.0.0.0")
           .withHttpApp(app)
           .resource

--- a/src/main/scala/kinesis/mock/KinesisMockService.scala
+++ b/src/main/scala/kinesis/mock/KinesisMockService.scala
@@ -1,6 +1,5 @@
 package kinesis.mock
 
-import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
 import cats.effect.concurrent.Semaphore


### PR DESCRIPTION
## Changes Introduced

Blaze is currently using ExecutionContext.global. This PR updates it to use IOApp.executionContext. 

This could potentially recreate the issue https://github.com/http4s/http4s/issues/4934, but under blaze.

## Applicable linked issues

## Checklist (check all that apply)

- [ ] This change maintains backwards compatibility
- [ ] I have introduced tests for all new features and changes
- [ ] I have added documentation covering all new features and changes
- [ ] This pull-request is ready for review