### PR TITLE
Fix PERSIST_PATH when using a root directory

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       # This must match 'initializedStreams' variable in AwsFunctionalTests
       - "INITIALIZE_STREAMS=stream1:3,stream2:2,stream3:1,stream4:2,stream5:3,stream6:5,stream7:5,stream8:3,stream9:1,stream10:3,stream11:2"
       - "SHOULD_PERSIST_DATA=true"
+      - "PERSIST_PATH=/tmp/datadir1"
     healthcheck:
       test: "curl --fail http://localhost:4568/healthcheck || exit 1"
       interval: 5s

--- a/src/main/scala/kinesis/mock/cache/PersistConfig.scala
+++ b/src/main/scala/kinesis/mock/cache/PersistConfig.scala
@@ -17,8 +17,8 @@ final case class PersistConfig(
     interval: FiniteDuration
 ) {
 
-  private def createPath(starting: os.Path): os.Path = {
-    val split = path.split("/").toList
+  private def createPath(starting: os.Path, p: String): os.Path = {
+    val split = p.split("/").toList
     split match {
       case Nil      => starting
       case h :: Nil => starting / h
@@ -29,9 +29,9 @@ final case class PersistConfig(
   def osPath: os.Path = if (path.isEmpty) os.pwd
   else {
     if (!path.startsWith("/")) {
-      createPath(os.pwd)
+      createPath(os.pwd, path)
     } else {
-      createPath(os.root)
+      createPath(os.root, path.drop(1))
     }
   }
   def osFile = osPath / fileName


### PR DESCRIPTION
## Changes Introduced

When using a root directory for the PERSIST_PATH, e.g. /tmp, there was a bug when parsing that as a path. This resolves that issue.

## Applicable linked issues

Resolves #125 

## Checklist (check all that apply)

- [x] This change maintains backwards compatibility
- [x] I have introduced tests for all new features and changes
- [ ] I have added documentation covering all new features and changes
- [x] This pull-request is ready for review