### PR TITLE
Fix for SHOULD_PERSIST_DATA

### DIFF
--- a/src/main/scala/kinesis/mock/cache/Cache.scala
+++ b/src/main/scala/kinesis/mock/cache/Cache.scala
@@ -1242,7 +1242,7 @@ object Cache {
   )(implicit C: Concurrent[IO], P: Parallel[IO]): IO[Cache] = {
     val om = new ObjectMapper()
 
-    IO(os.exists(config.persistConfig.osPath)).ifM(
+    IO(os.exists(config.persistConfig.osFile)).ifM(
       for {
         jn <- IO(om.readTree(config.persistConfig.osFile.toIO))
         streams <- IO.fromEither(jacksonToCirce(jn).as[Streams])


### PR DESCRIPTION
## Changes Introduced

The loading of the persisted data checked if the path existed but not the file. This change ensures that the routine checks if the file exists prior to loading from it.

## Applicable linked issues

#129 
https://github.com/localstack/localstack/issues/4227

## Checklist (check all that apply)

- [X] This change maintains backwards compatibility
- [ ] I have introduced tests for all new features and changes
- [ ] I have added documentation covering all new features and changes
- [X] This pull-request is ready for review