### PR TITLE
Use Modify instead of Get / Update for Ref Updates

### DIFF
--- a/src/fun/scala/kinesis/mock/PutRecordTests.scala
+++ b/src/fun/scala/kinesis/mock/PutRecordTests.scala
@@ -18,7 +18,7 @@ class PutRecordTests extends munit.CatsEffectSuite with AwsFunctionalTests {
     for {
       recordRequests <- IO(
         putRecordRequestArb.arbitrary
-          .take(5)
+          .take(20)
           .toVector
           .map(_.copy(streamName = resources.streamName))
           .map(x =>
@@ -34,7 +34,7 @@ class PutRecordTests extends munit.CatsEffectSuite with AwsFunctionalTests {
               .build()
           )
       )
-      _ <- recordRequests.traverse(x =>
+      _ <- recordRequests.parTraverse(x =>
         resources.kinesisClient.putRecord(x).toIO
       )
       shards <- resources.kinesisClient
@@ -68,7 +68,7 @@ class PutRecordTests extends munit.CatsEffectSuite with AwsFunctionalTests {
       )
       res = gets.flatMap(_.records().asScala.toVector)
     } yield assert(
-      res.length == 5 && res.forall(rec =>
+      res.length == 20 && res.forall(rec =>
         recordRequests.exists(req =>
           req.data.asByteArray.sameElements(rec.data.asByteArray)
             && req.partitionKey == rec.partitionKey

--- a/src/main/scala/kinesis/mock/api/AddTagsToStreamRequest.scala
+++ b/src/main/scala/kinesis/mock/api/AddTagsToStreamRequest.scala
@@ -8,6 +8,7 @@ import cats.syntax.all._
 import io.circe
 
 import kinesis.mock.models._
+import kinesis.mock.syntax.either._
 import kinesis.mock.validations.CommonValidations
 
 // https://docs.aws.amazon.com/kinesis/latest/APIReference/API_AddTagsToStream.html
@@ -19,7 +20,7 @@ final case class AddTagsToStreamRequest(
 ) {
   def addTagsToStream(
       streamsRef: Ref[IO, Streams]
-  ): IO[Response[Unit]] = streamsRef.get.flatMap { streams =>
+  ): IO[Response[Unit]] = streamsRef.modify { streams =>
     CommonValidations
       .validateStreamName(streamName)
       .flatMap(_ =>
@@ -62,11 +63,10 @@ final case class AddTagsToStreamRequest(
             ).mapN((_, _, _, _, _) => stream)
           )
       )
-      .traverse(stream =>
-        streamsRef.update(x =>
-          x.updateStream(stream.copy(tags = stream.tags |+| tags))
-        )
+      .map(stream =>
+        (streams.updateStream(stream.copy(tags = stream.tags |+| tags)), ())
       )
+      .sequenceWithDefault(streams)
   }
 }
 

--- a/src/main/scala/kinesis/mock/api/DeregisterStreamConsumerRequest.scala
+++ b/src/main/scala/kinesis/mock/api/DeregisterStreamConsumerRequest.scala
@@ -8,6 +8,7 @@ import cats.syntax.all._
 import io.circe
 
 import kinesis.mock.models._
+import kinesis.mock.syntax.either._
 import kinesis.mock.validations.CommonValidations
 
 // https://docs.aws.amazon.com/kinesis/latest/APIReference/API_DeregisterStreamConsumer.html
@@ -17,26 +18,26 @@ final case class DeregisterStreamConsumerRequest(
     streamArn: Option[String]
 ) {
   private def deregister(
-      streamsRef: Ref[IO, Streams],
+      streams: Streams,
       consumer: Consumer,
       stream: StreamData
-  ): IO[Consumer] = {
-    val newConsumer = consumer.copy(consumerStatus = ConsumerStatus.DELETING)
+  ): (Streams, Consumer) = {
+    val newConsumer =
+      consumer.copy(consumerStatus = ConsumerStatus.DELETING)
 
-    streamsRef
-      .update(x =>
-        x.updateStream(
-          stream.copy(consumers =
-            stream.consumers + (consumer.consumerName -> newConsumer)
-          )
+    (
+      streams.updateStream(
+        stream.copy(consumers =
+          stream.consumers + (consumer.consumerName -> newConsumer)
         )
-      )
-      .as(newConsumer)
+      ),
+      newConsumer
+    )
   }
 
   def deregisterStreamConsumer(
       streamsRef: Ref[IO, Streams]
-  ): IO[Response[Consumer]] = streamsRef.get.flatMap { streams =>
+  ): IO[Response[Consumer]] = streamsRef.modify { streams =>
     (consumerArn, consumerName, streamArn) match {
       case (Some(cArn), _, _) =>
         CommonValidations
@@ -50,9 +51,10 @@ final case class DeregisterStreamConsumerRequest(
                 s"Consumer $consumerName is not in an ACTIVE state"
               ).asLeft
           }
-          .traverse { case (consumer, stream) =>
-            deregister(streamsRef, consumer, stream)
+          .map { case (consumer, stream) =>
+            deregister(streams, consumer, stream)
           }
+          .sequenceWithDefault(streams)
       case (None, Some(cName), Some(sArn)) =>
         CommonValidations
           .findStreamByArn(sArn, streams)
@@ -68,11 +70,13 @@ final case class DeregisterStreamConsumerRequest(
 
             }
           }
-          .traverse { case (consumer, stream) =>
-            deregister(streamsRef, consumer, stream)
+          .map { case (consumer, stream) =>
+            deregister(streams, consumer, stream)
           }
+          .sequenceWithDefault(streams)
       case _ =>
-        IO(
+        (
+          streams,
           InvalidArgumentException(
             "ConsumerArn or both ConsumerName and StreamARN are required for this request."
           ).asLeft

--- a/src/main/scala/kinesis/mock/api/EnableEnhancedMonitoringRequest.scala
+++ b/src/main/scala/kinesis/mock/api/EnableEnhancedMonitoringRequest.scala
@@ -4,10 +4,10 @@ package api
 import cats.Eq
 import cats.effect.IO
 import cats.effect.concurrent.Ref
-import cats.syntax.all._
 import io.circe
 
 import kinesis.mock.models._
+import kinesis.mock.syntax.either._
 import kinesis.mock.validations.CommonValidations
 
 // https://docs.aws.amazon.com/kinesis/latest/APIReference/API_EnableEnhancedMonitoring.html
@@ -18,11 +18,11 @@ final case class EnableEnhancedMonitoringRequest(
   def enableEnhancedMonitoring(
       streamsRef: Ref[IO, Streams]
   ): IO[Response[EnableEnhancedMonitoringResponse]] =
-    streamsRef.get.flatMap { streams =>
+    streamsRef.modify { streams =>
       CommonValidations
         .validateStreamName(streamName)
         .flatMap(_ => CommonValidations.findStream(streamName, streams))
-        .traverse { stream =>
+        .map { stream =>
           val current = stream.enhancedMonitoring.flatMap(_.shardLevelMetrics)
           val desired =
             if (shardLevelMetrics.contains(ShardLevelMetric.ALL))
@@ -30,22 +30,19 @@ final case class EnableEnhancedMonitoringRequest(
                 .filterNot(_ == ShardLevelMetric.ALL)
                 .toVector
             else (current ++ shardLevelMetrics).distinct
-
-          streamsRef
-            .update(x =>
-              x.updateStream(
-                stream
-                  .copy(enhancedMonitoring = Vector(ShardLevelMetrics(desired)))
-              )
+          (
+            streams.updateStream(
+              stream
+                .copy(enhancedMonitoring = Vector(ShardLevelMetrics(desired)))
+            ),
+            EnableEnhancedMonitoringResponse(
+              current,
+              desired,
+              streamName
             )
-            .as(
-              EnableEnhancedMonitoringResponse(
-                current,
-                desired,
-                streamName
-              )
-            )
+          )
         }
+        .sequenceWithDefault(streams)
     }
 }
 

--- a/src/main/scala/kinesis/mock/api/IncreaseStreamRetentionPeriodRequest.scala
+++ b/src/main/scala/kinesis/mock/api/IncreaseStreamRetentionPeriodRequest.scala
@@ -10,6 +10,7 @@ import cats.syntax.all._
 import io.circe
 
 import kinesis.mock.models._
+import kinesis.mock.syntax.either._
 import kinesis.mock.validations.CommonValidations
 
 // https://docs.aws.amazon.com/kinesis/latest/APIReference/API_IncreaseStreamRetention.html
@@ -19,7 +20,7 @@ final case class IncreaseStreamRetentionPeriodRequest(
 ) {
   def increaseStreamRetention(
       streamsRef: Ref[IO, Streams]
-  ): IO[Response[Unit]] = streamsRef.get.flatMap { streams =>
+  ): IO[Response[Unit]] = streamsRef.modify { streams =>
     CommonValidations
       .validateStreamName(streamName)
       .flatMap(_ =>
@@ -38,13 +39,15 @@ final case class IncreaseStreamRetentionPeriodRequest(
             ).mapN((_, _, _) => stream)
           )
       )
-      .traverse(stream =>
-        streamsRef.update(streams =>
+      .map(stream =>
+        (
           streams.updateStream(
             stream.copy(retentionPeriod = retentionPeriodHours.hours)
-          )
+          ),
+          ()
         )
       )
+      .sequenceWithDefault(streams)
   }
 }
 

--- a/src/main/scala/kinesis/mock/api/PutRecordRequest.scala
+++ b/src/main/scala/kinesis/mock/api/PutRecordRequest.scala
@@ -11,6 +11,7 @@ import io.circe
 
 import kinesis.mock.instances.circe._
 import kinesis.mock.models._
+import kinesis.mock.syntax.either._
 import kinesis.mock.validations.CommonValidations
 
 final case class PutRecordRequest(
@@ -22,7 +23,7 @@ final case class PutRecordRequest(
 ) {
   def putRecord(
       streamsRef: Ref[IO, Streams]
-  ): IO[Response[PutRecordResponse]] = streamsRef.get.flatMap { streams =>
+  ): IO[Response[PutRecordResponse]] = streamsRef.modify { streams =>
     val now = Instant.now()
     CommonValidations
       .validateStreamName(streamName)
@@ -64,7 +65,7 @@ final case class PutRecordRequest(
             }
           }
       )
-      .traverse { case (stream, shard, records) =>
+      .map { case (stream, shard, records) =>
         val seqNo = SequenceNumber.create(
           shard.createdAtTimestamp,
           shard.shardId.index,
@@ -72,30 +73,28 @@ final case class PutRecordRequest(
           Some(records.length),
           Some(now)
         )
-        streamsRef
-          .update(x =>
-            x.updateStream {
-              stream.copy(
-                shards = stream.shards ++ Map(
-                  shard -> (records :+ KinesisRecord(
-                    now,
-                    data,
-                    stream.encryptionType,
-                    partitionKey,
-                    seqNo
-                  ))
-                )
+        (
+          streams.updateStream {
+            stream.copy(
+              shards = stream.shards ++ Map(
+                shard -> (records :+ KinesisRecord(
+                  now,
+                  data,
+                  stream.encryptionType,
+                  partitionKey,
+                  seqNo
+                ))
               )
-            }
-          )
-          .as(
-            PutRecordResponse(
-              stream.encryptionType,
-              seqNo,
-              shard.shardId.shardId
             )
+          },
+          PutRecordResponse(
+            stream.encryptionType,
+            seqNo,
+            shard.shardId.shardId
           )
+        )
       }
+      .sequenceWithDefault(streams)
   }
 }
 

--- a/src/main/scala/kinesis/mock/api/PutRecordsRequest.scala
+++ b/src/main/scala/kinesis/mock/api/PutRecordsRequest.scala
@@ -10,6 +10,7 @@ import cats.syntax.all._
 import io.circe
 
 import kinesis.mock.models._
+import kinesis.mock.syntax.either._
 import kinesis.mock.validations.CommonValidations
 
 final case class PutRecordsRequest(
@@ -19,7 +20,7 @@ final case class PutRecordsRequest(
   def putRecords(
       streamsRef: Ref[IO, Streams]
   ): IO[Response[PutRecordsResponse]] =
-    streamsRef.get.flatMap { streams =>
+    streamsRef.modify[Response[PutRecordsResponse]] { streams =>
       val now = Instant.now()
       CommonValidations
         .validateStreamName(streamName)
@@ -52,7 +53,7 @@ final case class PutRecordsRequest(
               ).mapN((_, recs) => (stream, recs))
             }
         )
-        .traverse { case (stream, recs) =>
+        .map { case (stream, recs) =>
           val grouped = recs
             .groupBy { case (shard, records, _) =>
               (shard, records)
@@ -97,26 +98,24 @@ final case class PutRecordsRequest(
               )
           }
 
-          streamsRef
-            .update(x =>
-              x.updateStream(
-                stream.copy(
-                  shards = stream.shards ++ newShards.map {
-                    case (shard, (records, _)) => shard -> records
-                  }
-                )
-              )
-            )
-            .as(
-              PutRecordsResponse(
-                stream.encryptionType,
-                0,
-                newShards.flatMap { case (_, (_, resultEntries)) =>
-                  resultEntries
+          (
+            streams.updateStream(
+              stream.copy(
+                shards = stream.shards ++ newShards.map {
+                  case (shard, (records, _)) => shard -> records
                 }
               )
+            ),
+            PutRecordsResponse(
+              stream.encryptionType,
+              0,
+              newShards.flatMap { case (_, (_, resultEntries)) =>
+                resultEntries
+              }
             )
+          )
         }
+        .sequenceWithDefault(streams)
     }
 }
 

--- a/src/main/scala/kinesis/mock/api/RemoveTagsFromStreamRequest.scala
+++ b/src/main/scala/kinesis/mock/api/RemoveTagsFromStreamRequest.scala
@@ -8,6 +8,7 @@ import cats.syntax.all._
 import io.circe
 
 import kinesis.mock.models._
+import kinesis.mock.syntax.either._
 import kinesis.mock.validations.CommonValidations
 
 final case class RemoveTagsFromStreamRequest(
@@ -19,7 +20,7 @@ final case class RemoveTagsFromStreamRequest(
   // https://docs.aws.amazon.com/directoryservice/latest/devguide/API_Tag.html
   def removeTagsFromStream(
       streamsRef: Ref[IO, Streams]
-  ): IO[Response[Unit]] = streamsRef.get.flatMap(streams =>
+  ): IO[Response[Unit]] = streamsRef.modify(streams =>
     CommonValidations
       .validateStreamName(streamName)
       .flatMap(_ =>
@@ -38,11 +39,13 @@ final case class RemoveTagsFromStreamRequest(
             ).mapN((_, _) => stream)
           )
       )
-      .traverse(stream =>
-        streamsRef.update(x =>
-          x.updateStream(stream.copy(tags = stream.tags -- tagKeys))
+      .map(stream =>
+        (
+          streams.updateStream(stream.copy(tags = stream.tags -- tagKeys)),
+          ()
         )
       )
+      .sequenceWithDefault(streams)
   )
 }
 

--- a/src/main/scala/kinesis/mock/api/SplitShardRequest.scala
+++ b/src/main/scala/kinesis/mock/api/SplitShardRequest.scala
@@ -4,12 +4,13 @@ package api
 import java.time.Instant
 
 import cats.Eq
+import cats.effect.IO
 import cats.effect.concurrent.Ref
-import cats.effect.{Concurrent, IO}
 import cats.syntax.all._
 import io.circe
 
 import kinesis.mock.models._
+import kinesis.mock.syntax.either._
 import kinesis.mock.validations.CommonValidations
 
 // https://docs.aws.amazon.com/kinesis/latest/APIReference/API_SplitShard.html
@@ -21,8 +22,8 @@ final case class SplitShardRequest(
   def splitShard(
       streamsRef: Ref[IO, Streams],
       shardLimit: Int
-  )(implicit C: Concurrent[IO]): IO[Response[Unit]] =
-    streamsRef.get.flatMap { streams =>
+  ): IO[Response[Unit]] =
+    streamsRef.modify { streams =>
       CommonValidations
         .validateStreamName(streamName)
         .flatMap(_ =>
@@ -63,7 +64,7 @@ final case class SplitShardRequest(
               }
             }
         )
-        .traverse { case (shard, shardData, stream) =>
+        .map { case (shard, shardData, stream) =>
           val now = Instant.now()
           val newStartingHashKeyNumber = BigInt(newStartingHashKey)
           val newShardIndex1 = stream.shards.keys.map(_.shardId.index).max + 1
@@ -109,17 +110,19 @@ final case class SplitShardRequest(
             )
           ) -> shardData
 
-          streamsRef.update(x =>
-            x.updateStream(
+          (
+            streams.updateStream(
               stream.copy(
                 shards = stream.shards.filterNot { case (shard, _) =>
                   shard.shardId == oldShard._1.shardId
                 } ++ (newShards :+ oldShard),
                 streamStatus = StreamStatus.UPDATING
               )
-            )
+            ),
+            ()
           )
         }
+        .sequenceWithDefault(streams)
     }
 }
 

--- a/src/main/scala/kinesis/mock/api/StopStreamEncryptionRequest.scala
+++ b/src/main/scala/kinesis/mock/api/StopStreamEncryptionRequest.scala
@@ -8,6 +8,7 @@ import cats.syntax.all._
 import io.circe
 
 import kinesis.mock.models._
+import kinesis.mock.syntax.either._
 import kinesis.mock.validations.CommonValidations
 
 final case class StopStreamEncryptionRequest(
@@ -17,7 +18,7 @@ final case class StopStreamEncryptionRequest(
 ) {
   def stopStreamEncryption(
       streamsRef: Ref[IO, Streams]
-  ): IO[Response[Unit]] = streamsRef.get.flatMap(streams =>
+  ): IO[Response[Unit]] = streamsRef.modify(streams =>
     CommonValidations
       .validateStreamName(streamName)
       .flatMap(_ =>
@@ -31,17 +32,19 @@ final case class StopStreamEncryptionRequest(
             ).mapN((_, _, _) => stream)
           )
       )
-      .traverse(stream =>
-        streamsRef.update(x =>
-          x.updateStream(
+      .map(stream =>
+        (
+          streams.updateStream(
             stream.copy(
               encryptionType = EncryptionType.NONE,
               streamStatus = StreamStatus.UPDATING,
               keyId = None
             )
-          )
+          ),
+          ()
         )
       )
+      .sequenceWithDefault(streams)
   )
 }
 

--- a/src/main/scala/kinesis/mock/cache/Cache.scala
+++ b/src/main/scala/kinesis/mock/cache/Cache.scala
@@ -103,10 +103,7 @@ class Cache private (
       req: CreateStreamRequest,
       context: LoggingContext,
       isCbor: Boolean
-  )(implicit
-      T: Timer[IO],
-      CS: ContextShift[IO]
-  ): IO[Response[Unit]] = {
+  )(implicit T: Timer[IO]): IO[Response[Unit]] = {
     val ctx = context + ("streamName" -> req.streamName.streamName)
     logger.debug(ctx.context)("Processing CreateStream request") *>
       logger.trace(ctx.addEncoded("request", req, isCbor).context)(
@@ -1041,10 +1038,7 @@ class Cache private (
       req: MergeShardsRequest,
       context: LoggingContext,
       isCbor: Boolean
-  )(implicit
-      T: Timer[IO],
-      CS: ContextShift[IO]
-  ): IO[Response[Unit]] = {
+  )(implicit T: Timer[IO]): IO[Response[Unit]] = {
     val ctx = context + ("streamName" -> req.streamName.streamName)
     logger.debug(ctx.context)(
       "Processing MergeShards request"
@@ -1096,10 +1090,7 @@ class Cache private (
       req: SplitShardRequest,
       context: LoggingContext,
       isCbor: Boolean
-  )(implicit
-      T: Timer[IO],
-      CS: ContextShift[IO]
-  ): IO[Response[Unit]] = {
+  )(implicit T: Timer[IO]): IO[Response[Unit]] = {
     val ctx = context + ("streamName" -> req.streamName.streamName)
     logger.debug(ctx.context)(
       "Processing SplitShard request"
@@ -1151,10 +1142,7 @@ class Cache private (
       req: UpdateShardCountRequest,
       context: LoggingContext,
       isCbor: Boolean
-  )(implicit
-      T: Timer[IO],
-      CS: ContextShift[IO]
-  ): IO[Response[Unit]] = {
+  )(implicit T: Timer[IO]): IO[Response[Unit]] = {
     val ctx = context + ("streamName" -> req.streamName.streamName)
     logger.debug(ctx.context)(
       "Processing UpdateShardCount request"

--- a/src/main/scala/kinesis/mock/syntax/either.scala
+++ b/src/main/scala/kinesis/mock/syntax/either.scala
@@ -1,0 +1,19 @@
+package kinesis.mock.syntax
+
+object either extends KinesisMockEitherSyntax
+
+trait KinesisMockEitherSyntax {
+  implicit def toKinesisMockEitherTupleOps[L, T1, T2](
+      e: Either[L, (T1, T2)]
+  ): KinesisMockEitherSyntax.KinesisMockEitherTupleOps[L, T1, T2] =
+    new KinesisMockEitherSyntax.KinesisMockEitherTupleOps(e)
+}
+
+object KinesisMockEitherSyntax {
+  final class KinesisMockEitherTupleOps[L, T1, T2](
+      private val e: Either[L, (T1, T2)]
+  ) extends AnyVal {
+    def sequenceWithDefault(default: T1): (T1, Either[L, T2]) =
+      e.fold(e => (default, Left(e)), { case (t1, t2) => (t1, Right(t2)) })
+  }
+}


### PR DESCRIPTION
## Changes Introduced

The current setup used `streamsRef.get`, calculated data via validations, then updated the Ref via `streamsRef.update`. This could cause potential issues when parallel requests are being processed, as data could have changed between the `get` and `update` calls.

This updates the API calls to use `streamsRef.modify`, and wraps all of the validations inside of the `modify`. This should ensure atomic updates to the Ref. 

## Applicable linked issues

#130 

## Checklist (check all that apply)

- [x] This change maintains backwards compatibility
- [x] I have introduced tests for all new features and changes
- [ ] I have added documentation covering all new features and changes
- [x] This pull-request is ready for review