### PR TITLE
Use Blocker for file write / read

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,3 +3,4 @@ coverage:
     project:
       default:
         threshold: 5%
+    patch: no

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -24,7 +24,7 @@ jobs:
       env:
         CBOR_ENABLED: ${{ matrix.cbor_enabled }}
         SERVICE_PORT: ${{ matrix.service_port }}
-        KINESIS_MOCK_DOCKERFILE: Dockerfile.Simple
+        # KINESIS_MOCK_DOCKERFILE: Dockerfile.Simple
     - name: Print Docker Container Listing
       if: ${{ failure() }}
       run: sbt dockerComposePs

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -24,6 +24,7 @@ jobs:
       env:
         CBOR_ENABLED: ${{ matrix.cbor_enabled }}
         SERVICE_PORT: ${{ matrix.service_port }}
+        KINESIS_MOCK_DOCKERFILE: Dockerfile.Simple
     - name: Print Docker Container Listing
       if: ${{ failure() }}
       run: sbt dockerComposePs

--- a/docker/Dockerfile.Simple
+++ b/docker/Dockerfile.Simple
@@ -1,0 +1,8 @@
+FROM azul/zulu-openjdk-alpine:11
+
+ARG DOCKER_SERVICE_JAR
+COPY ${DOCKER_SERVICE_JAR} ./kinesis-mock.jar
+RUN apk --no-cache add curl
+
+EXPOSE 4567 4568
+CMD ["java", "-jar", "kinesis-mock.jar"]

--- a/project/DockerImagePlugin.scala
+++ b/project/DockerImagePlugin.scala
@@ -55,7 +55,7 @@ object DockerImagePlugin extends AutoPlugin {
       dockerNamespace := "etspaceman",
       jarLocation := "docker/image/lib/",
       dockerfileLocation := "docker/",
-      dockerfile := "Dockerfile",
+      dockerfile := sys.env.getOrElse("KINESIS_MOCK_DOCKERFILE", "Dockerfile"),
       assembly / assemblyOutputPath := file(
         s"${jarLocation.value + name.value}.jar"
       ),

--- a/src/main/scala/kinesis/mock/KinesisMockService.scala
+++ b/src/main/scala/kinesis/mock/KinesisMockService.scala
@@ -34,7 +34,7 @@ object KinesisMockService extends IOApp {
         cache <- IO
           .pure(cacheConfig.persistConfig.loadIfExists)
           .ifM(
-            Cache.loadFromFile(cacheConfig),
+            Cache.loadFromFile(cacheConfig, blocker),
             Cache(cacheConfig)
           )
         _ <- initializeStreams(
@@ -75,12 +75,13 @@ object KinesisMockService extends IOApp {
               cacheConfig.persistConfig.shouldPersist,
               cacheConfig.persistConfig.interval,
               cache,
-              logger
+              logger,
+              blocker
             ).background
           )
           .onFinalize(
             IO.pure(cacheConfig.persistConfig.shouldPersist)
-              .ifM(cache.persistToDisk(LoggingContext.create), IO.unit)
+              .ifM(cache.persistToDisk(LoggingContext.create, blocker), IO.unit)
           )
           .use(_ => IO.never)
           .as(ExitCode.Success)
@@ -132,7 +133,8 @@ object KinesisMockService extends IOApp {
       shouldPersist: Boolean,
       interval: FiniteDuration,
       cache: Cache,
-      logger: SelfAwareStructuredLogger[IO]
+      logger: SelfAwareStructuredLogger[IO],
+      blocker: Blocker
   ): IO[Unit] = {
     val context = LoggingContext.create
     IO.pure(shouldPersist)
@@ -144,7 +146,7 @@ object KinesisMockService extends IOApp {
             noop[IO, Unit],
             (e: Throwable, _) =>
               logger.error(context.context, e)("Failed to persist data")
-          )(cache.persistToDisk(context)),
+          )(cache.persistToDisk(context, blocker)),
         logger.info(LoggingContext.create.context)(
           "Not configured to persist data, persist loop not started"
         )

--- a/src/test/scala/kinesis/mock/cache/PersistenceTests.scala
+++ b/src/test/scala/kinesis/mock/cache/PersistenceTests.scala
@@ -56,8 +56,8 @@ class PersistenceTests
           _ <- recordRequests.traverse(req =>
             cache.putRecord(req, context, false).rethrow
           )
-          _ <- cache.persistToDisk(context)
-          newCache <- Cache.loadFromFile(cacheConfig)
+          _ <- cache.persistToDisk(context, blocker)
+          newCache <- Cache.loadFromFile(cacheConfig, blocker)
           shard <- newCache
             .listShards(
               ListShardsRequest(None, None, None, None, None, Some(streamName)),


### PR DESCRIPTION
## Changes Introduced

The persist file write / read functions should leverage `Blocker` as they are blocking IO. This updates that.

## Applicable linked issues

N/A

## Checklist (check all that apply)

- [x] This change maintains backwards compatibility
- [ ] I have introduced tests for all new features and changes
- [ ] I have added documentation covering all new features and changes
- [ ] This pull-request is ready for review