### PR TITLE
Use AsyncAppender for logback

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -5,7 +5,10 @@
     </encoder>
   </appender>
   <logger name="kinesis.mock" level="${LOG_LEVEL:-INFO}"/>
-  <root level="${ROOT_LOG_LEVEL:-ERROR}">
+  <appender name="ASYNC" class="ch.qos.logback.classic.AsyncAppender">
     <appender-ref ref="STDOUT" />
+  </appender>
+  <root level="${ROOT_LOG_LEVEL:-ERROR}">
+    <appender-ref ref="ASYNC" />
   </root>
 </configuration>


### PR DESCRIPTION
## Changes Introduced

Using the AsyncAppender for logback should help in environments where TRACE logging is enabled, as the logs can be a bit noisy.

## Applicable linked issues

N/A

## Checklist (check all that apply)

- [x] This change maintains backwards compatibility
- [ ] I have introduced tests for all new features and changes
- [ ] I have added documentation covering all new features and changes
- [x] This pull-request is ready for review