### PR TITLE
Use SortedMap to maintain ordering

### DIFF
--- a/src/fun/scala/kinesis/mock/ListStreamConsumersTests.scala
+++ b/src/fun/scala/kinesis/mock/ListStreamConsumersTests.scala
@@ -16,7 +16,7 @@ class ListStreamConsumersTests
 
   fixture.test("It should list stream consumers") { resources =>
     for {
-      consumerNames <- IO(consumerNameGen.take(3).toVector.map(_.consumerName))
+      consumerNames <- IO(consumerNameGen.take(3).toVector.sorted.map(_.consumerName))
       streamSummary <- describeStreamSummary(resources)
       streamArn = streamSummary.streamDescriptionSummary().streamARN()
       registerRes <- consumerNames.traverse(consumerName =>

--- a/src/fun/scala/kinesis/mock/ListStreamConsumersTests.scala
+++ b/src/fun/scala/kinesis/mock/ListStreamConsumersTests.scala
@@ -16,7 +16,9 @@ class ListStreamConsumersTests
 
   fixture.test("It should list stream consumers") { resources =>
     for {
-      consumerNames <- IO(consumerNameGen.take(3).toVector.sorted.map(_.consumerName))
+      consumerNames <- IO(
+        consumerNameGen.take(3).toVector.sorted.map(_.consumerName)
+      )
       streamSummary <- describeStreamSummary(resources)
       streamArn = streamSummary.streamDescriptionSummary().streamARN()
       registerRes <- consumerNames.traverse(consumerName =>

--- a/src/fun/scala/kinesis/mock/ListStreamConsumersTests.scala
+++ b/src/fun/scala/kinesis/mock/ListStreamConsumersTests.scala
@@ -40,7 +40,6 @@ class ListStreamConsumersTests
         .consumers()
         .asScala
         .toVector
-        .sortBy(_.consumerName())
         .map(x =>
           models.ConsumerSummary(
             x.consumerARN(),
@@ -50,7 +49,6 @@ class ListStreamConsumersTests
           )
         ) === registerRes
         .map(_.consumer())
-        .sortBy(_.consumerName())
         .map(x =>
           models.ConsumerSummary(
             x.consumerARN(),

--- a/src/main/scala/kinesis/mock/api/CreateStreamRequest.scala
+++ b/src/main/scala/kinesis/mock/api/CreateStreamRequest.scala
@@ -41,7 +41,8 @@ final case class CreateStreamRequest(shardCount: Int, streamName: StreamName) {
         val newStream =
           StreamData.create(shardCount, streamName, awsRegion, awsAccountId)
         (
-          streams.copy(streams = streams.streams + (streamName -> newStream)),
+          streams
+            .copy(streams = streams.streams ++ Seq(streamName -> newStream)),
           ()
         )
       }.sequenceWithDefault(streams)

--- a/src/main/scala/kinesis/mock/api/DeleteStreamRequest.scala
+++ b/src/main/scala/kinesis/mock/api/DeleteStreamRequest.scala
@@ -1,6 +1,8 @@
 package kinesis.mock
 package api
 
+import scala.collection.SortedMap
+
 import cats.Eq
 import cats.effect.IO
 import cats.effect.concurrent.Ref
@@ -41,11 +43,11 @@ final case class DeleteStreamRequest(
         .map { stream =>
           val deletingStream = Map(
             streamName -> stream.copy(
-              shards = Map.empty,
+              shards = SortedMap.empty,
               streamStatus = StreamStatus.DELETING,
               tags = Tags.empty,
               enhancedMonitoring = Vector.empty,
-              consumers = Map.empty
+              consumers = SortedMap.empty
             )
           )
           (

--- a/src/main/scala/kinesis/mock/api/DeregisterStreamConsumerRequest.scala
+++ b/src/main/scala/kinesis/mock/api/DeregisterStreamConsumerRequest.scala
@@ -28,7 +28,7 @@ final case class DeregisterStreamConsumerRequest(
     (
       streams.updateStream(
         stream.copy(consumers =
-          stream.consumers + (consumer.consumerName -> newConsumer)
+          stream.consumers ++ Seq(consumer.consumerName -> newConsumer)
         )
       ),
       newConsumer

--- a/src/main/scala/kinesis/mock/api/ListShardsRequest.scala
+++ b/src/main/scala/kinesis/mock/api/ListShardsRequest.scala
@@ -50,7 +50,7 @@ final case class ListShardsRequest(
                 case None     => Right(())
               }
             ).mapN((_, _, stream, _, _) => {
-              val allShards = stream.shards.keys.toVector.sorted
+              val allShards = stream.shards.keys.toVector
               val lastShardIndex = allShards.length - 1
               val limit = maxResults.map(l => Math.min(l, 100)).getOrElse(100)
               val firstIndex =
@@ -83,7 +83,7 @@ final case class ListShardsRequest(
                 case None     => Right(())
               }
             ).mapN((_, _, _) => {
-              val allShards: Vector[Shard] = stream.shards.keys.toVector.sorted
+              val allShards: Vector[Shard] = stream.shards.keys.toVector
               val filteredShards = shardFilter match {
                 case Some(sf)
                     if sf.`type` == ShardFilterType.AT_TRIM_HORIZON ||

--- a/src/main/scala/kinesis/mock/api/ListStreamsRequest.scala
+++ b/src/main/scala/kinesis/mock/api/ListStreamsRequest.scala
@@ -28,7 +28,7 @@ final case class ListStreamsRequest(
         case None    => Right(())
       }
     ).mapN((_, _) => {
-      val allStreams = streams.streams.keys.toVector.sorted
+      val allStreams = streams.streams.keys.toVector
       val lastStreamIndex = allStreams.length - 1
       val lim = limit.map(l => Math.min(l, 100)).getOrElse(100)
       val firstIndex = exclusiveStartStreamName

--- a/src/main/scala/kinesis/mock/api/ListTagsForStreamRequest.scala
+++ b/src/main/scala/kinesis/mock/api/ListTagsForStreamRequest.scala
@@ -1,6 +1,8 @@
 package kinesis.mock
 package api
 
+import scala.collection.SortedMap
+
 import cats.Eq
 import cats.effect.IO
 import cats.effect.concurrent.Ref
@@ -43,7 +45,7 @@ final case class ListTagsForStreamRequest(
                   .map(x => allTags.indexWhere(_._1 == x) + 1)
                   .getOrElse(0)
                 val lastIndex = Math.min(firstIndex + lim, lastTagIndex + 1)
-                val tags = Map.from(allTags.slice(firstIndex, lastIndex))
+                val tags = SortedMap.from(allTags.slice(firstIndex, lastIndex))
                 val hasMoreTags =
                   if (lastTagIndex + 1 == lastIndex) false
                   else true

--- a/src/main/scala/kinesis/mock/api/RegisterStreamConsumerRequest.scala
+++ b/src/main/scala/kinesis/mock/api/RegisterStreamConsumerRequest.scala
@@ -55,7 +55,9 @@ final case class RegisterStreamConsumerRequest(
           (
             streams.updateStream(
               stream
-                .copy(consumers = stream.consumers + (consumerName -> consumer))
+                .copy(consumers =
+                  stream.consumers ++ Seq(consumerName -> consumer)
+                )
             ),
             RegisterStreamConsumerResponse(
               ConsumerSummary.fromConsumer(consumer)

--- a/src/main/scala/kinesis/mock/models/Shard.scala
+++ b/src/main/scala/kinesis/mock/models/Shard.scala
@@ -1,6 +1,8 @@
 package kinesis.mock
 package models
 
+import scala.collection.SortedMap
+
 import java.time.Instant
 
 import cats.Eq
@@ -31,9 +33,9 @@ object Shard {
       shardCount: Int,
       createTime: Instant,
       startingIndex: Int
-  ): Map[Shard, Vector[KinesisRecord]] = {
+  ): SortedMap[Shard, Vector[KinesisRecord]] = {
     val shardHash = maxHashKey / BigInt(shardCount)
-    Map.from(
+    SortedMap.from(
       Vector
         .range(startingIndex, shardCount + startingIndex, 1)
         .zipWithIndex

--- a/src/main/scala/kinesis/mock/models/StreamData.scala
+++ b/src/main/scala/kinesis/mock/models/StreamData.scala
@@ -1,6 +1,7 @@
 package kinesis.mock
 package models
 
+import scala.collection.SortedMap
 import scala.concurrent.duration._
 
 import java.time.Instant
@@ -13,12 +14,12 @@ import io.circe.derivation._
 import kinesis.mock.instances.circe._
 
 final case class StreamData(
-    consumers: Map[ConsumerName, Consumer],
+    consumers: SortedMap[ConsumerName, Consumer],
     encryptionType: EncryptionType,
     enhancedMonitoring: Vector[ShardLevelMetrics],
     keyId: Option[String],
     retentionPeriod: FiniteDuration,
-    shards: Map[Shard, Vector[KinesisRecord]],
+    shards: SortedMap[Shard, Vector[KinesisRecord]],
     streamArn: String,
     streamCreationTimestamp: Instant,
     streamName: StreamName,
@@ -67,10 +68,10 @@ object StreamData {
   ): StreamData = {
 
     val createTime = Instant.now()
-    val shards: Map[Shard, Vector[KinesisRecord]] =
+    val shards: SortedMap[Shard, Vector[KinesisRecord]] =
       Shard.newShards(shardCount, createTime, 0)
     StreamData(
-      Map.empty,
+      SortedMap.empty,
       EncryptionType.NONE,
       Vector(ShardLevelMetrics(Vector.empty)),
       None,

--- a/src/main/scala/kinesis/mock/models/Streams.scala
+++ b/src/main/scala/kinesis/mock/models/Streams.scala
@@ -1,20 +1,24 @@
 package kinesis.mock
 package models
 
+import scala.collection.SortedMap
+
 import cats.Eq
 import cats.syntax.all._
 import io.circe._
 import io.circe.derivation._
 
-final case class Streams(streams: Map[StreamName, StreamData]) {
+final case class Streams(streams: SortedMap[StreamName, StreamData]) {
   def updateStream(stream: StreamData): Streams =
-    copy(streams = streams + (stream.streamName -> stream))
+    copy(streams = streams ++ Seq(stream.streamName -> stream))
   def findAndUpdateStream(
       streamName: StreamName
   )(f: StreamData => StreamData): Streams =
     streams
       .get(streamName)
-      .map(stream => copy(streams = streams + (stream.streamName -> f(stream))))
+      .map(stream =>
+        copy(streams = streams ++ Seq(stream.streamName -> f(stream)))
+      )
       .getOrElse(this)
 
   def addStream(
@@ -24,12 +28,14 @@ final case class Streams(streams: Map[StreamName, StreamData]) {
       awsAccountId: AwsAccountId
   ): Streams =
     copy(streams =
-      streams + (streamName -> StreamData.create(
-        shardCount,
-        streamName,
-        awsRegion,
-        awsAccountId
-      ))
+      streams ++ Seq(
+        streamName -> StreamData.create(
+          shardCount,
+          streamName,
+          awsRegion,
+          awsAccountId
+        )
+      )
     )
 
   def deleteStream(
@@ -38,23 +44,25 @@ final case class Streams(streams: Map[StreamName, StreamData]) {
     .get(streamName)
     .map(stream =>
       copy(streams =
-        streams + (streamName -> stream.copy(
-          shards = Map.empty,
-          streamStatus = StreamStatus.DELETING,
-          tags = Tags.empty,
-          enhancedMonitoring = Vector.empty,
-          consumers = Map.empty
-        ))
+        streams ++ Seq(
+          streamName -> stream.copy(
+            shards = SortedMap.empty,
+            streamStatus = StreamStatus.DELETING,
+            tags = Tags.empty,
+            enhancedMonitoring = Vector.empty,
+            consumers = SortedMap.empty
+          )
+        )
       )
     )
     .getOrElse(this)
 
   def removeStream(streamName: StreamName): Streams =
-    copy(streams = streams - streamName)
+    copy(streams = streams.filterNot { case (x, _) => streamName == x })
 }
 
 object Streams {
-  val empty: Streams = Streams(Map.empty)
+  val empty: Streams = Streams(SortedMap.empty)
   implicit val streamsCirceEncoder: Encoder[Streams] = deriveEncoder
   implicit val streamsCirceDecoder: Decoder[Streams] = deriveDecoder
   implicit val streamsEq: Eq[Streams] = (x, y) =>

--- a/src/main/scala/kinesis/mock/models/Tags.scala
+++ b/src/main/scala/kinesis/mock/models/Tags.scala
@@ -1,9 +1,11 @@
 package kinesis.mock.models
 
+import scala.collection.SortedMap
+
 import cats.{Eq, Monoid}
 import io.circe._
 
-final case class Tags(tags: Map[String, String]) {
+final case class Tags(tags: SortedMap[String, String]) {
   def size: Int = tags.size
   def --(keys: IterableOnce[String]): Tags = copy(tags = tags.filterNot {
     case (key, _) => keys.iterator.contains(key)
@@ -13,14 +15,14 @@ final case class Tags(tags: Map[String, String]) {
 }
 
 object Tags {
-  def empty: Tags = Tags(Map.empty)
+  def empty: Tags = Tags(SortedMap.empty)
   def fromTagList(tagList: TagList): Tags = Tags(
-    Map.from(tagList.tags.map(x => (x.key, x.value)))
+    SortedMap.from(tagList.tags.map(x => (x.key, x.value)))
   )
   implicit val tagsCirceEncoder: Encoder[Tags] =
-    Encoder[Map[String, String]].contramap(_.tags)
+    Encoder[SortedMap[String, String]].contramap(_.tags)
   implicit val tagsCirceDecoder: Decoder[Tags] =
-    Decoder[Map[String, String]].map(Tags.apply)
+    Decoder[SortedMap[String, String]].map(Tags.apply)
   implicit val tagsEq: Eq[Tags] = Eq.fromUniversalEquals
   implicit val tagsMonoid: Monoid[Tags] = new Monoid[Tags] {
     override def combine(x: Tags, y: Tags): Tags = Tags(x.tags ++ y.tags)

--- a/src/test/scala/kinesis/mock/api/AddTagsToStreamTests.scala
+++ b/src/test/scala/kinesis/mock/api/AddTagsToStreamTests.scala
@@ -1,6 +1,8 @@
 package kinesis.mock
 package api
 
+import scala.collection.SortedMap
+
 import cats.effect.IO
 import cats.effect.concurrent.Ref
 import enumeratum.scalacheck._
@@ -47,8 +49,8 @@ class AddTagsToStreamTests
 
       val tagKey = tagKeyGen.one
       val tagValue = tagValueGen.one
-      val tags = Tags(Map(tagKey -> tagValue))
-      val initialTags = Tags(Map(tagKey -> "initial"))
+      val tags = Tags(SortedMap(tagKey -> tagValue))
+      val initialTags = Tags(SortedMap(tagKey -> "initial"))
 
       val streamsWithTag = streams.findAndUpdateStream(streamName)(stream =>
         stream.copy(tags = initialTags)

--- a/src/test/scala/kinesis/mock/api/DeleteStreamTests.scala
+++ b/src/test/scala/kinesis/mock/api/DeleteStreamTests.scala
@@ -1,5 +1,7 @@
 package kinesis.mock.api
 
+import scala.collection.SortedMap
+
 import cats.effect.IO
 import cats.effect.concurrent.Ref
 import enumeratum.scalacheck._
@@ -84,8 +86,9 @@ class DeleteStreamTests
 
       val withConsumers = streams.findAndUpdateStream(streamName)(x =>
         x.copy(
-          consumers =
-            Map(consumerName -> Consumer.create(x.streamArn, consumerName)),
+          consumers = SortedMap(
+            consumerName -> Consumer.create(x.streamArn, consumerName)
+          ),
           streamStatus = StreamStatus.ACTIVE
         )
       )
@@ -114,8 +117,9 @@ class DeleteStreamTests
 
       val withConsumers = streams.findAndUpdateStream(streamName)(x =>
         x.copy(
-          consumers =
-            Map(consumerName -> Consumer.create(x.streamArn, consumerName)),
+          consumers = SortedMap(
+            consumerName -> Consumer.create(x.streamArn, consumerName)
+          ),
           streamStatus = StreamStatus.ACTIVE
         )
       )

--- a/src/test/scala/kinesis/mock/api/DeregisterStreamConsumerTests.scala
+++ b/src/test/scala/kinesis/mock/api/DeregisterStreamConsumerTests.scala
@@ -1,6 +1,8 @@
 package kinesis.mock
 package api
 
+import scala.collection.SortedMap
+
 import cats.effect.IO
 import cats.effect.concurrent.Ref
 import enumeratum.scalacheck._
@@ -24,7 +26,7 @@ class DeregisterStreamConsumerTests
       val updated = streams.findAndUpdateStream(streamName) { stream =>
         stream.copy(
           streamStatus = StreamStatus.ACTIVE,
-          consumers = Map(
+          consumers = SortedMap(
             consumerName -> Consumer
               .create(stream.streamArn, consumerName)
               .copy(consumerStatus = ConsumerStatus.ACTIVE)
@@ -65,7 +67,7 @@ class DeregisterStreamConsumerTests
       val updated = streams.findAndUpdateStream(streamName) { stream =>
         stream.copy(
           streamStatus = StreamStatus.ACTIVE,
-          consumers = Map(
+          consumers = SortedMap(
             consumerName -> Consumer
               .create(stream.streamArn, consumerName)
               .copy(consumerStatus = ConsumerStatus.ACTIVE)
@@ -105,7 +107,7 @@ class DeregisterStreamConsumerTests
       val updated = streams.findAndUpdateStream(streamName) { stream =>
         stream.copy(
           streamStatus = StreamStatus.ACTIVE,
-          consumers = Map(
+          consumers = SortedMap(
             consumerName -> Consumer
               .create(stream.streamArn, consumerName)
           )
@@ -166,7 +168,7 @@ class DeregisterStreamConsumerTests
       val updated = streams.findAndUpdateStream(streamName) { stream =>
         stream.copy(
           streamStatus = StreamStatus.ACTIVE,
-          consumers = Map(
+          consumers = SortedMap(
             consumerName -> Consumer
               .create(stream.streamArn, consumerName)
               .copy(consumerStatus = ConsumerStatus.ACTIVE)
@@ -198,7 +200,7 @@ class DeregisterStreamConsumerTests
       val updated = streams.findAndUpdateStream(streamName) { stream =>
         stream.copy(
           streamStatus = StreamStatus.ACTIVE,
-          consumers = Map(
+          consumers = SortedMap(
             consumerName -> Consumer
               .create(stream.streamArn, consumerName)
               .copy(consumerStatus = ConsumerStatus.ACTIVE)

--- a/src/test/scala/kinesis/mock/api/DescribeStreamConsumerTests.scala
+++ b/src/test/scala/kinesis/mock/api/DescribeStreamConsumerTests.scala
@@ -1,6 +1,8 @@
 package kinesis.mock
 package api
 
+import scala.collection.SortedMap
+
 import cats.effect.IO
 import cats.effect.concurrent.Ref
 import enumeratum.scalacheck._
@@ -24,7 +26,7 @@ class DescribeStreamConsumerTests
       val updated = streams.findAndUpdateStream(streamName) { stream =>
         stream.copy(
           streamStatus = StreamStatus.ACTIVE,
-          consumers = Map(
+          consumers = SortedMap(
             consumerName -> Consumer
               .create(stream.streamArn, consumerName)
               .copy(consumerStatus = ConsumerStatus.ACTIVE)
@@ -61,7 +63,7 @@ class DescribeStreamConsumerTests
       val updated = streams.findAndUpdateStream(streamName) { stream =>
         stream.copy(
           streamStatus = StreamStatus.ACTIVE,
-          consumers = Map(
+          consumers = SortedMap(
             consumerName -> Consumer
               .create(stream.streamArn, consumerName)
               .copy(consumerStatus = ConsumerStatus.ACTIVE)
@@ -120,7 +122,7 @@ class DescribeStreamConsumerTests
       val updated = streams.findAndUpdateStream(streamName) { stream =>
         stream.copy(
           streamStatus = StreamStatus.ACTIVE,
-          consumers = Map(
+          consumers = SortedMap(
             consumerName -> Consumer
               .create(stream.streamArn, consumerName)
               .copy(consumerStatus = ConsumerStatus.ACTIVE)
@@ -149,7 +151,7 @@ class DescribeStreamConsumerTests
       val updated = streams.findAndUpdateStream(streamName) { stream =>
         stream.copy(
           streamStatus = StreamStatus.ACTIVE,
-          consumers = Map(
+          consumers = SortedMap(
             consumerName -> Consumer
               .create(stream.streamArn, consumerName)
               .copy(consumerStatus = ConsumerStatus.ACTIVE)

--- a/src/test/scala/kinesis/mock/api/GetRecordsTests.scala
+++ b/src/test/scala/kinesis/mock/api/GetRecordsTests.scala
@@ -1,6 +1,8 @@
 package kinesis.mock
 package api
 
+import scala.collection.SortedMap
+
 import cats.effect.IO
 import cats.effect.concurrent.Ref
 import cats.syntax.all._
@@ -41,7 +43,7 @@ class GetRecordsTests
 
       val withRecords = streams.findAndUpdateStream(streamName) { s =>
         s.copy(
-          shards = Map(s.shards.head._1 -> records),
+          shards = SortedMap(s.shards.head._1 -> records),
           streamStatus = StreamStatus.ACTIVE
         )
       }
@@ -94,7 +96,7 @@ class GetRecordsTests
 
       val withRecords = streams.findAndUpdateStream(streamName) { s =>
         s.copy(
-          shards = Map(s.shards.head._1 -> records),
+          shards = SortedMap(s.shards.head._1 -> records),
           streamStatus = StreamStatus.ACTIVE
         )
       }
@@ -147,7 +149,7 @@ class GetRecordsTests
 
       val withRecords = streams.findAndUpdateStream(streamName) { s =>
         s.copy(
-          shards = Map(s.shards.head._1 -> records),
+          shards = SortedMap(s.shards.head._1 -> records),
           streamStatus = StreamStatus.ACTIVE
         )
       }
@@ -216,7 +218,7 @@ class GetRecordsTests
 
       val withRecords = streams.findAndUpdateStream(streamName) { s =>
         s.copy(
-          shards = Map(s.shards.head._1 -> records),
+          shards = SortedMap(s.shards.head._1 -> records),
           streamStatus = StreamStatus.ACTIVE
         )
       }

--- a/src/test/scala/kinesis/mock/api/GetShardIteratorTests.scala
+++ b/src/test/scala/kinesis/mock/api/GetShardIteratorTests.scala
@@ -1,6 +1,8 @@
 package kinesis.mock
 package api
 
+import scala.collection.SortedMap
+
 import java.time.Instant
 
 import cats.effect.IO
@@ -42,7 +44,7 @@ class GetShardIteratorTests
 
       val withRecords = streams.findAndUpdateStream(streamName) { s =>
         s.copy(
-          shards = Map(s.shards.head._1 -> records),
+          shards = SortedMap(s.shards.head._1 -> records),
           streamStatus = StreamStatus.ACTIVE
         )
       }
@@ -95,7 +97,7 @@ class GetShardIteratorTests
 
       val withRecords = streams.findAndUpdateStream(streamName) { s =>
         s.copy(
-          shards = Map(s.shards.head._1 -> records),
+          shards = SortedMap(s.shards.head._1 -> records),
           streamStatus = StreamStatus.ACTIVE
         )
       }
@@ -152,7 +154,7 @@ class GetShardIteratorTests
 
       val withRecords = streams.findAndUpdateStream(streamName) { s =>
         s.copy(
-          shards = Map(s.shards.head._1 -> records),
+          shards = SortedMap(s.shards.head._1 -> records),
           streamStatus = StreamStatus.ACTIVE
         )
       }
@@ -209,7 +211,7 @@ class GetShardIteratorTests
 
       val withRecords = streams.findAndUpdateStream(streamName) { s =>
         s.copy(
-          shards = Map(s.shards.head._1 -> records),
+          shards = SortedMap(s.shards.head._1 -> records),
           streamStatus = StreamStatus.ACTIVE
         )
       }
@@ -264,7 +266,7 @@ class GetShardIteratorTests
 
       val withRecords = streams.findAndUpdateStream(streamName) { s =>
         s.copy(
-          shards = Map(s.shards.head._1 -> records),
+          shards = SortedMap(s.shards.head._1 -> records),
           streamStatus = StreamStatus.ACTIVE
         )
       }
@@ -318,7 +320,7 @@ class GetShardIteratorTests
 
         val withRecords = streams.findAndUpdateStream(streamName) { s =>
           s.copy(
-            shards = Map(s.shards.head._1 -> records),
+            shards = SortedMap(s.shards.head._1 -> records),
             streamStatus = StreamStatus.ACTIVE
           )
         }
@@ -375,7 +377,7 @@ class GetShardIteratorTests
 
         val withRecords = streams.findAndUpdateStream(streamName) { s =>
           s.copy(
-            shards = Map(s.shards.head._1 -> records),
+            shards = SortedMap(s.shards.head._1 -> records),
             streamStatus = StreamStatus.ACTIVE
           )
         }

--- a/src/test/scala/kinesis/mock/api/ListStreamConsumersTests.scala
+++ b/src/test/scala/kinesis/mock/api/ListStreamConsumersTests.scala
@@ -1,6 +1,8 @@
 package kinesis.mock
 package api
 
+import scala.collection.SortedMap
+
 import cats.effect.IO
 import cats.effect.concurrent.Ref
 import cats.syntax.all._
@@ -24,7 +26,7 @@ class ListStreamConsumersTests
       val streams =
         Streams.empty.addStream(100, streamName, awsRegion, awsAccountId)
 
-      val consumers = Map.from(
+      val consumers = SortedMap.from(
         Gen
           .listOfN(5, consumerArbitrary.arbitrary)
           .suchThat(x =>
@@ -87,7 +89,7 @@ class ListStreamConsumersTests
       val streams =
         Streams.empty.addStream(100, streamName, awsRegion, awsAccountId)
 
-      val consumers = Map.from(
+      val consumers = SortedMap.from(
         Gen
           .listOfN(10, consumerArbitrary.arbitrary)
           .suchThat(x =>

--- a/src/test/scala/kinesis/mock/api/ListTagsForStreamTests.scala
+++ b/src/test/scala/kinesis/mock/api/ListTagsForStreamTests.scala
@@ -1,6 +1,8 @@
 package kinesis.mock
 package api
 
+import scala.collection.SortedMap
+
 import cats.effect.IO
 import cats.effect.concurrent.Ref
 import enumeratum.scalacheck._
@@ -50,7 +52,7 @@ class ListTagsForStreamTests
 
       val tags: Tags = Gen
         .mapOfN(10, Gen.zip(tagKeyGen, tagValueGen))
-        .map(x => Map.from(x))
+        .map(x => SortedMap.from(x))
         .map(Tags.apply)
         .one
 
@@ -88,7 +90,7 @@ class ListTagsForStreamTests
 
       val tags: Tags = Gen
         .mapOfN(10, Gen.zip(tagKeyGen, tagValueGen))
-        .map(x => Map.from(x))
+        .map(x => SortedMap.from(x))
         .map(Tags.apply)
         .one
 

--- a/src/test/scala/kinesis/mock/api/MergeShardsTests.scala
+++ b/src/test/scala/kinesis/mock/api/MergeShardsTests.scala
@@ -24,7 +24,7 @@ class MergeShardsTests
         streams.findAndUpdateStream(streamName)(s =>
           s.copy(streamStatus = StreamStatus.ACTIVE)
         )
-      val shards = active.streams(streamName).shards.keys.toVector.sorted
+      val shards = active.streams(streamName).shards.keys.toVector
 
       val shardToMerge = shards.head
       val adjacentShardToMerge = shards(1)
@@ -62,7 +62,7 @@ class MergeShardsTests
       val streams =
         Streams.empty.addStream(5, streamName, awsRegion, awsAccountId)
 
-      val shards = streams.streams(streamName).shards.keys.toVector.sorted
+      val shards = streams.streams(streamName).shards.keys.toVector
 
       val shardToMerge = shards.head
       val adjacentShardToMerge = shards(1)
@@ -94,7 +94,7 @@ class MergeShardsTests
       val active = streams.findAndUpdateStream(streamName)(s =>
         s.copy(streamStatus = StreamStatus.ACTIVE)
       )
-      val shards = active.streams(streamName).shards.keys.toVector.sorted
+      val shards = active.streams(streamName).shards.keys.toVector
       val shardToMerge = shards.head
       val adjacentShardToMerge =
         ShardId.create(shards.map(_.shardId.index).max + 1)
@@ -126,7 +126,7 @@ class MergeShardsTests
       val active = streams.findAndUpdateStream(streamName)(s =>
         s.copy(streamStatus = StreamStatus.ACTIVE)
       )
-      val shards = active.streams(streamName).shards.keys.toVector.sorted
+      val shards = active.streams(streamName).shards.keys.toVector
       val shardToMerge =
         ShardId.create(shards.map(_.shardId.index).max + 1)
 
@@ -159,7 +159,7 @@ class MergeShardsTests
       val active = streams.findAndUpdateStream(streamName)(s =>
         s.copy(streamStatus = StreamStatus.ACTIVE)
       )
-      val shards = streams.streams(streamName).shards.keys.toVector.sorted
+      val shards = streams.streams(streamName).shards.keys.toVector
       val shardToMerge = shards.head
       val adjacentShardToMerge = shards(2)
 

--- a/src/test/scala/kinesis/mock/api/RegisterStreamConsumerTests.scala
+++ b/src/test/scala/kinesis/mock/api/RegisterStreamConsumerTests.scala
@@ -1,6 +1,8 @@
 package kinesis.mock
 package api
 
+import scala.collection.SortedMap
+
 import cats.effect.IO
 import cats.effect.concurrent.Ref
 import enumeratum.scalacheck._
@@ -49,7 +51,7 @@ class RegisterStreamConsumerTests
       val streams =
         Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
-      val consumers = Map.from(
+      val consumers = SortedMap.from(
         Gen
           .listOfN(20, consumerArbitrary.arbitrary)
           .suchThat(x =>
@@ -85,7 +87,7 @@ class RegisterStreamConsumerTests
         val streams =
           Streams.empty.addStream(1, streamName, awsRegion, awsAccountId)
 
-        val consumers = Map.from(
+        val consumers = SortedMap.from(
           Gen
             .listOfN(5, consumerArbitrary.arbitrary)
             .suchThat(x =>

--- a/src/test/scala/kinesis/mock/api/RemoveTagsFromStreamTests.scala
+++ b/src/test/scala/kinesis/mock/api/RemoveTagsFromStreamTests.scala
@@ -1,6 +1,8 @@
 package kinesis.mock
 package api
 
+import scala.collection.SortedMap
+
 import cats.effect.IO
 import cats.effect.concurrent.Ref
 import enumeratum.scalacheck._
@@ -25,7 +27,7 @@ class RemoveTagsFromStreamTests
 
       val tags: Tags = Gen
         .mapOfN(10, Gen.zip(tagKeyGen, tagValueGen))
-        .map(x => Map.from(x))
+        .map(x => SortedMap.from(x))
         .map(Tags.apply)
         .one
 

--- a/src/test/scala/kinesis/mock/api/UpdateShardCountTests.scala
+++ b/src/test/scala/kinesis/mock/api/UpdateShardCountTests.scala
@@ -38,14 +38,13 @@ class UpdateShardCountTests
         s <- streamsRef.get
       } yield assert(
         res.isRight && s.streams.get(streamName).exists { stream =>
-          val shards = stream.shards.keys.toVector.sorted
+          val shards = stream.shards.keys.toVector
           shards.count(_.isOpen) == 10 &&
           shards.filterNot(_.isOpen).map(_.shardId) == active
             .streams(streamName)
             .shards
             .keys
             .toVector
-            .sorted
             .map(_.shardId) &&
           stream.streamStatus == StreamStatus.UPDATING &&
           res.exists { r =>
@@ -88,14 +87,13 @@ class UpdateShardCountTests
         s <- streamsRef.get
       } yield assert(
         res.isRight && s.streams.get(streamName).exists { stream =>
-          val shards = stream.shards.keys.toVector.sorted
+          val shards = stream.shards.keys.toVector
           shards.count(_.isOpen) == 5 &&
           shards.filterNot(_.isOpen).map(_.shardId) == active
             .streams(streamName)
             .shards
             .keys
             .toVector
-            .sorted
             .map(_.shardId) &&
           stream.streamStatus == StreamStatus.UPDATING &&
           res.exists { r =>

--- a/src/test/scala/kinesis/mock/cache/ListStreamConsumersTests.scala
+++ b/src/test/scala/kinesis/mock/cache/ListStreamConsumersTests.scala
@@ -51,14 +51,15 @@ class ListStreamConsumersTests
               )
               .one
           )
-          registerResults <- consumerNames.toVector.traverse(consumerName =>
-            cache
-              .registerStreamConsumer(
-                RegisterStreamConsumerRequest(consumerName, streamArn),
-                context,
-                false
-              )
-              .rethrow
+          registerResults <- consumerNames.sorted.toVector.traverse(
+            consumerName =>
+              cache
+                .registerStreamConsumer(
+                  RegisterStreamConsumerRequest(consumerName, streamArn),
+                  context,
+                  false
+                )
+                .rethrow
           )
           res <- cache
             .listStreamConsumers(
@@ -68,11 +69,10 @@ class ListStreamConsumersTests
             )
             .rethrow
         } yield assert(
-          res.consumers.sortBy(_.consumerName) == registerResults
-            .map(_.consumer)
-            .sortBy(_.consumerName),
-          s"${registerResults.map(_.consumer).sortBy(_.consumerName)}\n" +
-            s"${res.consumers.sortBy(_.consumerName)}"
+          res.consumers == registerResults
+            .map(_.consumer),
+          s"${registerResults.map(_.consumer)}\n" +
+            s"${res.consumers}"
         )
       )
   })

--- a/src/test/scala/kinesis/mock/cache/ListStreamsTests.scala
+++ b/src/test/scala/kinesis/mock/cache/ListStreamsTests.scala
@@ -26,6 +26,7 @@ class ListStreamsTests extends munit.CatsEffectSuite {
                 .isEmpty
             )
             .one
+            .sorted
         )
         _ <- streamNames.traverse(streamName =>
           cache
@@ -40,8 +41,8 @@ class ListStreamsTests extends munit.CatsEffectSuite {
           )
           .rethrow
       } yield assert(
-        res.streamNames == streamNames.sorted,
-        s"${res.streamNames}\n${streamNames.sorted}"
+        res.streamNames == streamNames,
+        s"${res.streamNames}\n${streamNames}"
       )
     )
   )

--- a/src/test/scala/kinesis/mock/cache/PutRecordsTests.scala
+++ b/src/test/scala/kinesis/mock/cache/PutRecordsTests.scala
@@ -41,7 +41,7 @@ class PutRecordsTests
               streamName
             )
           )
-          _ <- cache.putRecords(req, context, false).rethrow
+          putRecordsResponse <- cache.putRecords(req, context, false).rethrow
           shard <- cache
             .listShards(
               ListShardsRequest(None, None, None, None, None, Some(streamName)),
@@ -73,7 +73,9 @@ class PutRecordsTests
               req.data.sameElements(rec.data)
                 && req.partitionKey == rec.partitionKey
             )
-          ),
+          ) && putRecordsResponse.records.flatMap(
+            _.shardId.toVector
+          ) == putRecordsResponse.records.flatMap(_.shardId.toVector).sorted,
           s"${res.records}\n$req"
         )
       )

--- a/src/test/scala/kinesis/mock/instances/arbitrary.scala
+++ b/src/test/scala/kinesis/mock/instances/arbitrary.scala
@@ -1,5 +1,6 @@
 package kinesis.mock.instances
 
+import scala.collection.SortedMap
 import scala.collection.immutable.Queue
 import scala.concurrent.duration._
 
@@ -214,7 +215,7 @@ object arbitrary {
   val tagsGen: Gen[Tags] = Gen
     .choose(0, 10)
     .flatMap(size => Gen.mapOfN(size, Gen.zip(tagKeyGen, tagValueGen)))
-    .map(x => Map.from(x))
+    .map(x => SortedMap.from(x))
     .map(Tags.apply)
 
   implicit val tagListArb: Arbitrary[TagList] = Arbitrary(
@@ -868,7 +869,7 @@ object arbitrary {
           consumersSize,
           consumerArbitrary.arbitrary.map(x => x.consumerName -> x)
         )
-        .map(x => Map.from(x))
+        .map(x => SortedMap.from(x))
       encryptionType <- Arbitrary.arbitrary[EncryptionType]
       enhancedMonitoring <- Gen
         .choose(0, 1)
@@ -883,7 +884,7 @@ object arbitrary {
       shardsSize <- Gen.choose(0, 50)
       shardList <- Gen
         .containerOfN[Vector, Shard](shardsSize, shardArbitrary.arbitrary)
-      shards <- Gen.sequence[Map[
+      shards <- Gen.sequence[SortedMap[
         Shard,
         Vector[KinesisRecord]
       ], (Shard, Vector[KinesisRecord])](
@@ -931,7 +932,7 @@ object arbitrary {
       .suchThat(x =>
         x.groupBy(_.streamName).filter { case (_, x) => x.length > 1 }.isEmpty
       )
-      .map(x => Streams(Map.from(x.map(sd => sd.streamName -> sd))))
+      .map(x => Streams(SortedMap.from(x.map(sd => sd.streamName -> sd))))
   }
 
 }


### PR DESCRIPTION
## Changes Introduced

Re-introduced SortedMap for the shards, consumers and streams listings, which will maintain ordering of the keys. 

## Applicable linked issues

#148 

## Checklist (check all that apply)

- [x] This change maintains backwards compatibility
- [x] I have introduced tests for all new features and changes
- [ ] I have added documentation covering all new features and changes
- [x] This pull-request is ready for review