### PR TITLE
Fix ordering of PutRecordsResultEntry

### DIFF
--- a/src/main/scala/kinesis/mock/api/PutRecordsRequest.scala
+++ b/src/main/scala/kinesis/mock/api/PutRecordsRequest.scala
@@ -1,6 +1,8 @@
 package kinesis.mock
 package api
 
+import scala.collection.mutable.HashMap
+
 import java.time.Instant
 
 import cats.Eq
@@ -54,63 +56,58 @@ final case class PutRecordsRequest(
             }
         )
         .map { case (stream, recs) =>
-          val grouped = recs
-            .groupBy { case (shard, records, _) =>
-              (shard, records)
-            }
-            .map { case ((shard, records), list) =>
-              (shard, records) ->
-                list.map(_._3).zipWithIndex.map { case (entry, index) =>
-                  val seqNo = SequenceNumber.create(
-                    shard.createdAtTimestamp,
-                    shard.shardId.index,
-                    None,
-                    Some(records.length + index),
-                    Some(now)
-                  )
-                  (
-                    KinesisRecord(
-                      now,
-                      entry.data,
-                      stream.encryptionType,
-                      entry.partitionKey,
-                      seqNo
-                    ),
-                    PutRecordsResultEntry(
-                      None,
-                      None,
-                      Some(seqNo),
-                      Some(shard.shardId.shardId)
-                    )
-                  )
-                }
-            }
-            .toVector
+          val asRecords = PutRecordsRequest
+            .getIndexByShard(recs)
+            .map { case (shard, records, entry, index) =>
+              val seqNo = SequenceNumber.create(
+                shard.createdAtTimestamp,
+                shard.shardId.index,
+                None,
+                Some(records.length + index),
+                Some(now)
+              )
 
-          val newShards = grouped.map {
-            case ((shard, currentRecords), recordsToAdd) =>
               (
                 shard,
-                (
-                  currentRecords ++ recordsToAdd.map(_._1),
-                  recordsToAdd.map(_._2)
+                records,
+                KinesisRecord(
+                  now,
+                  entry.data,
+                  stream.encryptionType,
+                  entry.partitionKey,
+                  seqNo
+                ),
+                PutRecordsResultEntry(
+                  None,
+                  None,
+                  Some(seqNo),
+                  Some(shard.shardId.shardId)
                 )
               )
-          }
+            }
+
+          val newShards = asRecords
+            .groupBy { case (shard, currentRecords, _, _) =>
+              (shard, currentRecords)
+            }
+            .map { case ((shard, currentRecords), recordsToAdd) =>
+              (
+                shard,
+                currentRecords ++ recordsToAdd.map(_._3)
+              )
+            }
 
           (
             streams.updateStream(
               stream.copy(
-                shards = stream.shards ++ newShards.map {
-                  case (shard, (records, _)) => shard -> records
-                }
+                shards = stream.shards ++ newShards
               )
             ),
             PutRecordsResponse(
               stream.encryptionType,
               0,
-              newShards.flatMap { case (_, (_, resultEntries)) =>
-                resultEntries
+              asRecords.map { case (_, _, _, entry) =>
+                entry
               }
             )
           )
@@ -120,6 +117,18 @@ final case class PutRecordsRequest(
 }
 
 object PutRecordsRequest {
+  private def getIndexByShard(
+      records: Vector[(Shard, Vector[KinesisRecord], PutRecordsRequestEntry)]
+  ): Vector[(Shard, Vector[KinesisRecord], PutRecordsRequestEntry, Int)] = {
+    val indexMap: HashMap[Shard, Int] = new HashMap()
+
+    records.map { case (shard, records, entry) =>
+      val i = indexMap.get(shard).fold(0)(_ + 1)
+      indexMap += shard -> i
+      (shard, records, entry, i)
+    }
+  }
+
   implicit val putRecordsRequestCirceEncoder: circe.Encoder[PutRecordsRequest] =
     circe.Encoder.forProduct2("Records", "StreamName")(x =>
       (x.records, x.streamName)

--- a/src/test/scala/kinesis/mock/PutRecordsResults.scala
+++ b/src/test/scala/kinesis/mock/PutRecordsResults.scala
@@ -1,0 +1,25 @@
+package kinesis.mock
+
+import cats.Eq
+
+import kinesis.mock.api.{PutRecordRequest, PutRecordsRequestEntry}
+import kinesis.mock.models.KinesisRecord
+
+final case class PutRecordResults(
+    data: Array[Byte],
+    partitionKey: String
+)
+
+object PutRecordResults {
+  def fromKinesisRecord(x: KinesisRecord): PutRecordResults =
+    PutRecordResults(x.data, x.partitionKey)
+
+  def fromPutRecordsRequestEntry(x: PutRecordsRequestEntry): PutRecordResults =
+    PutRecordResults(x.data, x.partitionKey)
+
+  def fromPutRecordRequest(x: PutRecordRequest): PutRecordResults =
+    PutRecordResults(x.data, x.partitionKey)
+
+  implicit val putRecordResultsEq: Eq[PutRecordResults] = (x, y) =>
+    x.data.sameElements(y.data) && x.partitionKey == y.partitionKey
+}

--- a/src/test/scala/kinesis/mock/api/PutRecordsTests.scala
+++ b/src/test/scala/kinesis/mock/api/PutRecordsTests.scala
@@ -52,7 +52,6 @@ class PutRecordsTests
             req.records.map(_.data).exists(_.sameElements(rec.data))
           } == initReq.records.length && res.exists { r =>
             r.records.map(_.shardId) == predictedShards
-
           }
         },
         s"req: $req\nres: $res"

--- a/src/test/scala/kinesis/mock/cache/PutRecordTests.scala
+++ b/src/test/scala/kinesis/mock/cache/PutRecordTests.scala
@@ -1,4 +1,5 @@
-package kinesis.mock.cache
+package kinesis.mock
+package cache
 
 import scala.concurrent.duration._
 
@@ -68,12 +69,9 @@ class PutRecordTests
             .getRecords(GetRecordsRequest(None, shardIterator), context, false)
             .rethrow
         } yield assert(
-          res.records.length == 5 && res.records.forall(rec =>
-            recordRequests.exists(req =>
-              req.data.sameElements(rec.data)
-                && req.partitionKey == rec.partitionKey
-            )
-          ),
+          res.records.length == 5 && res.records.toVector.map(
+            PutRecordResults.fromKinesisRecord
+          ) === recordRequests.map(PutRecordResults.fromPutRecordRequest),
           s"${res.records}\n$recordRequests"
         )
       )


### PR DESCRIPTION
## Changes Introduced

There was a `groupBy` that was causing the PutRecordsResultEntry listing to be out of order from the submission. While the data was put in order on the shard itself, the response was out of order. This resolves that.

## Applicable linked issues

#148 

## Checklist (check all that apply)

- [x] This change maintains backwards compatibility
- [ ] I have introduced tests for all new features and changes
- [ ] I have added documentation covering all new features and changes
- [x] This pull-request is ready for review