### PR TITLE
Add AsyncAppender to reflect-config for native-image

### DIFF
--- a/graal/reflect-config.json
+++ b/graal/reflect-config.json
@@ -174,6 +174,11 @@
         "allDeclaredConstructors": true
     },
     {
+        "name": "ch.qos.logback.classic.AsyncAppender",
+        "allPublicMethods":true,
+        "allDeclaredConstructors": true
+    },
+    {
         "name": "com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl",
         "allDeclaredConstructors": true
     }


### PR DESCRIPTION
## Changes Introduced

The AsyncAppender class was not included in the reflect-config.json, which was causing some errors when loading the logback config. This should fix that.

## Applicable linked issues

#154 

## Checklist (check all that apply)

- [ ] This change maintains backwards compatibility
- [ ] I have introduced tests for all new features and changes
- [ ] I have added documentation covering all new features and changes
- [ ] This pull-request is ready for review