### PR TITLE
Fix Tag Regex

### DIFF
--- a/src/main/scala/kinesis/mock/api/AddTagsToStreamRequest.scala
+++ b/src/main/scala/kinesis/mock/api/AddTagsToStreamRequest.scala
@@ -37,7 +37,7 @@ final case class AddTagsToStreamRequest(
                 else Right(())
               }, {
                 val invalidValues = tags.tags.values.filterNot(x =>
-                  x.matches("^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-]*)$")
+                  x.matches("^([\\p{L}\\p{Z}\\p{N}_./=+\\-%@]*)$")
                 )
                 if (invalidValues.nonEmpty)
                   InvalidArgumentException(

--- a/src/main/scala/kinesis/mock/validations/CommonValidations.scala
+++ b/src/main/scala/kinesis/mock/validations/CommonValidations.scala
@@ -148,7 +148,7 @@ object CommonValidations {
         else Right(())
       }, {
         val invalidKeyCharacters =
-          keys.filterNot(x => x.matches("^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-]*)$"))
+          keys.filterNot(x => x.matches("^([\\p{L}\\p{Z}\\p{N}_./=+\\-%@]*)$"))
         if (invalidKeyCharacters.nonEmpty)
           InvalidArgumentException(
             s"Keys contain invalid characters. Invalid keys: ${invalidKeyCharacters.mkString(", ")}"

--- a/src/test/scala/kinesis/mock/instances/arbitrary.scala
+++ b/src/test/scala/kinesis/mock/instances/arbitrary.scala
@@ -202,14 +202,14 @@ object arbitrary {
     .choose(1, 128)
     .flatMap(size =>
       Gen
-        .resize(size, RegexpGen.from("^([a-zA-Z0-9_.:/=+\\-]*)$"))
+        .resize(size, RegexpGen.from("^([a-zA-Z0-9_./=+\\-%@ ]*)$"))
         .suchThat(x => !x.startsWith("aws:") && x.nonEmpty)
     )
 
   val tagValueGen: Gen[String] = Gen
     .choose(0, 256)
     .flatMap(size =>
-      Gen.resize(size, RegexpGen.from("^([a-zA-Z0-9_.:/=+\\-]*)$"))
+      Gen.resize(size, RegexpGen.from("^([a-zA-Z0-9_./=+\\-%@ ]*)$"))
     )
 
   val tagsGen: Gen[Tags] = Gen


### PR DESCRIPTION
## Changes Introduced

The tag validation in place did not allow some characters that should have been allowed (`%` and `@`), and allowed a character that should have been rejected (`:`). This PR fixes this.

## Applicable linked issues

https://github.com/localstack/localstack/issues/4489

## Checklist (check all that apply)

- [X] This change maintains backwards compatibility
- [X] I have introduced tests for all new features and changes
- [ ] I have added documentation covering all new features and changes
- [X] This pull-request is ready for review