### PR TITLE
Update mergify config

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,3 +1,15 @@
+queue_rules:
+  - name: default
+    speculative_checks: 3
+    conditions:
+      - author=scala-steward
+      - status-success=build (false, 4567)
+      - status-success=build (false, 4568)
+      - status-success=build (true, 4567)
+      - status-success=build (true, 4568)
+      - status-success=codecov/project
+    
+
 pull_request_rules:
   - name: assign and label scala-steward's PRs
     conditions:
@@ -16,6 +28,6 @@ pull_request_rules:
       - status-success=build (true, 4568)
       - status-success=codecov/project
     actions:
-      merge:
+      queue:
+        name: default
         method: squash
-        strict: true


### PR DESCRIPTION
## Changes Introduced

Using the queue as `strict` has been deprecated for Mergify:

https://blog.mergify.com/strict-mode-deprecation/

## Applicable linked issues

## Checklist (check all that apply)

- [ ] This change maintains backwards compatibility
- [ ] I have introduced tests for all new features and changes
- [ ] I have added documentation covering all new features and changes
- [ ] This pull-request is ready for review