### PR TITLE
Always Create New Shard Iterators

### DIFF
--- a/src/main/scala/kinesis/mock/api/GetRecordsRequest.scala
+++ b/src/main/scala/kinesis/mock/api/GetRecordsRequest.scala
@@ -54,7 +54,11 @@ final case class GetRecordsRequest(
                           GetRecordsResponse(
                             childShards,
                             0L,
-                            shardIterator,
+                            ShardIterator.create(
+                              parts.streamName,
+                              parts.shardId,
+                              parts.sequenceNumber
+                            ),
                             Queue.empty
                           )
                         )
@@ -102,7 +106,11 @@ final case class GetRecordsRequest(
                                 GetRecordsResponse(
                                   childShards,
                                   0L,
-                                  shardIterator,
+                                  ShardIterator.create(
+                                    parts.streamName,
+                                    parts.shardId,
+                                    parts.sequenceNumber
+                                  ),
                                   Queue.empty
                                 )
                               )


### PR DESCRIPTION
## Changes Introduced

GetRecords used to return the passed shard-iterator if no data was to be returned. This was causing issues because shard-iterators time out after 5 minutes. While the KCL handled this fine, dynamodb streams did not.

## Applicable linked issues

#260 

## Checklist (check all that apply)

- [x] This change maintains backwards compatibility
- [ ] I have introduced tests for all new features and changes
- [ ] I have added documentation covering all new features and changes
- [x] This pull-request is ready for review