### PR TITLE
Fix hash key ranges when splitting a shard

### DIFF
--- a/src/main/scala/kinesis/mock/api/SplitShardRequest.scala
+++ b/src/main/scala/kinesis/mock/api/SplitShardRequest.scala
@@ -76,8 +76,8 @@ final case class SplitShardRequest(
             None,
             now,
             HashKeyRange(
-              shard.hashKeyRange.startingHashKey,
-              newStartingHashKeyNumber - BigInt(1)
+              startingHashKey = shard.hashKeyRange.startingHashKey,
+              endingHashKey = newStartingHashKeyNumber - BigInt(1)
             ),
             Some(shard.shardId.shardId),
             SequenceNumberRange(
@@ -92,8 +92,8 @@ final case class SplitShardRequest(
             None,
             now,
             HashKeyRange(
-              newStartingHashKeyNumber,
-              shard.hashKeyRange.endingHashKey
+              startingHashKey = newStartingHashKeyNumber,
+              endingHashKey = shard.hashKeyRange.endingHashKey
             ),
             Some(shard.shardId.shardId),
             SequenceNumberRange(


### PR DESCRIPTION
## Changes Introduced

Fixes hash key ranges of new shards when a shard is split. Starting and ending keys were swapped.

## Applicable linked issues

https://github.com/etspaceman/kinesis-mock/issues/378

## Checklist (check all that apply)

- [x] This change maintains backwards compatibility
- [x] I have introduced tests for all new features and changes
- [ ] I have added documentation covering all new features and changes
- [x] This pull-request is ready for review