### PR TITLE
Fix Auth Header parsing for values that don't contain spaces between commas

### DIFF
--- a/src/main/scala/kinesis/mock/KinesisMockRoutes.scala
+++ b/src/main/scala/kinesis/mock/KinesisMockRoutes.scala
@@ -180,6 +180,7 @@ class KinesisMockRoutes(cache: Cache) {
                   Authorization=AWS4-HMAC-SHA256 Credential=mock-kinesis-access-key/20210402/us-east-1/kinesis/aws4_request, SignedHeaders=amz-sdk-invocation-id;amz-sdk-request;content-length;content-type;host;x-amz-date;x-amz-target, Signature=4a789f84587c3592d3ebd2fcc25e2cdcbc01bc3312771f5170b253ab6a5fedb6
                    */
                   val authParsed = authHeader.value
+                    .replace(",", ", ")
                     .split(" ")
                     .toVector
                     .map(_.replace(",", ""))

--- a/src/test/scala/kinesis/mock/KinesisMockServiceTests.scala
+++ b/src/test/scala/kinesis/mock/KinesisMockServiceTests.scala
@@ -91,6 +91,39 @@ class KinesisMockServiceTests
     }
   }
 
+  test("it should accept auth headers without spaces between commas") {
+    PropF.forAllF { (streamName: StreamName) =>
+      for {
+        cacheConfig <- CacheConfig.read
+        cache <- Cache(cacheConfig)
+        app = new KinesisMockRoutes(cache).routes.orNotFound
+        origin: Origin = Origin.Null
+        request = Request(
+          method = Method.POST,
+          headers = Headers(
+            List(
+              origin.toRaw1,
+              AmazonAuthorization(
+                "AWS4-HMAC-SHA256 " +
+                  "Credential=mock-kinesis-access-key/20210402/us-east-1/kinesis/aws4_request," +
+                  "SignedHeaders=amz-sdk-invocation-id;amz-sdk-request;content-length;content-type;host;x-amz-date;x-amz-target," +
+                  "Signature=4a789f84587c3592d3ebd2fcc25e2cdcbc01bc3312771f5170b253ab6a5fedb6"
+              ).toRaw1,
+              AmazonDateHeader("20150830T123600Z").toRaw1,
+              AmazonTarget("Kinesis_20131202.CreateStream").toRaw1,
+              `Content-Type`(KinesisMockMediaTypes.amazonCbor).toRaw1
+            )
+          ),
+          body = kinesisMockEntityEncoder[CreateStreamRequest](
+            KinesisMockMediaTypes.amazonCbor
+          ).toEntity(CreateStreamRequest(Some(1), None, streamName)).body
+        )
+        res <- app.run(request)
+      } yield assert(res.status.isSuccess, res)
+
+    }
+  }
+
   test("it should accept valid JSON requests using headers") {
     PropF.forAllF { (streamName: StreamName) =>
       for {


### PR DESCRIPTION
## Changes Introduced

Fixed parsing of Auth headers that don't have spaces between commas

## Applicable linked issues

#387

## Checklist (check all that apply)

- [X] This change maintains backwards compatibility
- [X] I have introduced tests for all new features and changes
- [ ] I have added documentation covering all new features and changes
- [X] This pull-request is ready for review