### PR TITLE
Accept StreamARN for PutRecord(s)

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,8 +9,7 @@ services:
   localstack:
     image: "localstack/localstack:latest"
     environment:
-      - "SERVICES=cloudwatch"
-      - "USE_SSL=true"
+      - "SERVICES=cloudwatch,sts"
     healthcheck:
       test: "awslocal cloudwatch list-metrics"
       interval: 5s

--- a/project/LibraryDependencies.scala
+++ b/project/LibraryDependencies.scala
@@ -38,7 +38,7 @@ object LibraryDependencies {
     val sdkVersion = "2.19.21"
     val utils = "software.amazon.awssdk" % "utils" % sdkVersion
     val kinesis = "software.amazon.awssdk" % "kinesis" % sdkVersion
-    val kpl = "com.amazonaws" % "amazon-kinesis-producer" % "0.14.13"
+    val kpl = "com.amazonaws" % "amazon-kinesis-producer" % "0.15.2"
     val kcl = "software.amazon.kinesis" % "amazon-kinesis-client" % "2.4.4"
   }
 

--- a/src/fun/scala/kinesis/mock/GetRecordsTests.scala
+++ b/src/fun/scala/kinesis/mock/GetRecordsTests.scala
@@ -20,12 +20,14 @@ class GetRecordsTests extends AwsFunctionalTests {
         putRecordRequestArb.arbitrary
           .take(5)
           .toVector
-          .map(_.copy(streamName = resources.streamName))
+          .map(
+            _.copy(streamName = Some(resources.streamName), streamArn = None)
+          )
           .map(x =>
             PutRecordRequest
               .builder()
               .partitionKey(x.partitionKey)
-              .streamName(x.streamName.streamName)
+              .streamName(resources.streamName.streamName)
               .data(SdkBytes.fromByteArray(x.data))
               .maybeTransform(x.explicitHashKey)(_.explicitHashKey(_))
               .maybeTransform(x.sequenceNumberForOrdering)((req, sequenceNum) =>

--- a/src/fun/scala/kinesis/mock/KPLTests.scala
+++ b/src/fun/scala/kinesis/mock/KPLTests.scala
@@ -32,6 +32,8 @@ class KPLTests extends AwsFunctionalTests {
                 .setKinesisPort(4567L) // KPL only supports TLS
                 .setCloudwatchEndpoint("localhost")
                 .setCloudwatchPort(4566L)
+                .setStsEndpoint("localhost")
+                .setStsPort(4566L)
                 .setVerifyCertificate(false)
             )
           )

--- a/src/fun/scala/kinesis/mock/PutRecordTests.scala
+++ b/src/fun/scala/kinesis/mock/PutRecordTests.scala
@@ -20,12 +20,14 @@ class PutRecordTests extends AwsFunctionalTests {
         putRecordRequestArb.arbitrary
           .take(20)
           .toVector
-          .map(_.copy(streamName = resources.streamName))
+          .map(
+            _.copy(streamName = Some(resources.streamName), streamArn = None)
+          )
           .map(x =>
             PutRecordRequest
               .builder()
               .partitionKey(x.partitionKey)
-              .streamName(x.streamName.streamName)
+              .streamName(resources.streamName.streamName)
               .data(SdkBytes.fromByteArray(x.data))
               .maybeTransform(x.explicitHashKey)(_.explicitHashKey(_))
               .maybeTransform(x.sequenceNumberForOrdering)((req, sequenceNum) =>

--- a/src/main/scala/kinesis/mock/cache/Cache.scala
+++ b/src/main/scala/kinesis/mock/cache/Cache.scala
@@ -1147,7 +1147,10 @@ class Cache private (
       isCbor: Boolean,
       region: Option[AwsRegion]
   ): IO[Response[PutRecordResponse]] = {
-    val ctx = context + ("streamName" -> req.streamName.streamName)
+    val ctx =
+      context ++
+        req.streamName.map(x => "streamName" -> x.streamName).toList ++
+        req.streamArn.map(x => "streamArn" -> x.streamArn).toList
     for {
       _ <- logger.debug(ctx.context)("Processing PutRecord request")
       _ <- logger.trace(context.addEncoded("request", req, isCbor).context)(
@@ -1181,7 +1184,9 @@ class Cache private (
       isCbor: Boolean,
       region: Option[AwsRegion]
   ): IO[Response[PutRecordsResponse]] = {
-    val ctx = context + ("streamName" -> req.streamName.streamName)
+    val ctx = context ++
+      req.streamName.map(x => "streamName" -> x.streamName).toList ++
+      req.streamArn.map(x => "streamArn" -> x.streamArn).toList
     for {
       _ <- logger.debug(ctx.context)("Processing PutRecords request")
       _ <- logger.trace(context.addEncoded("request", req, isCbor).context)(

--- a/src/test/scala/kinesis/mock/api/PutRecordTests.scala
+++ b/src/test/scala/kinesis/mock/api/PutRecordTests.scala
@@ -24,7 +24,8 @@ class PutRecordTests
         )
 
       val req = initReq.copy(
-        streamName = streamArn.streamName
+        streamArn = Some(streamArn),
+        streamName = None
       )
 
       for {
@@ -55,7 +56,8 @@ class PutRecordTests
           Streams.empty.addStream(1, streamArn, None)
 
         val req = initReq.copy(
-          streamName = streamArn.streamName
+          streamArn = Some(streamArn),
+          streamName = None
         )
 
         for {
@@ -89,7 +91,8 @@ class PutRecordTests
         )
 
         val req = initReq.copy(
-          streamName = streamArn.streamName
+          streamArn = Some(streamArn),
+          streamName = None
         )
 
         for {

--- a/src/test/scala/kinesis/mock/api/PutRecordsTests.scala
+++ b/src/test/scala/kinesis/mock/api/PutRecordsTests.scala
@@ -25,7 +25,8 @@ class PutRecordsTests
         )
 
       val req = initReq.copy(
-        streamName = streamArn.streamName
+        streamArn = Some(streamArn),
+        streamName = None
       )
 
       val predictedShards = req.records.map(entry =>
@@ -69,7 +70,8 @@ class PutRecordsTests
           Streams.empty.addStream(1, streamArn, None)
 
         val req = initReq.copy(
-          streamName = streamArn.streamName
+          streamArn = Some(streamArn),
+          streamName = None
         )
 
         for {
@@ -103,7 +105,8 @@ class PutRecordsTests
         )
 
         val req = initReq.copy(
-          streamName = streamArn.streamName
+          streamArn = Some(streamArn),
+          streamName = None
         )
 
         for {

--- a/src/test/scala/kinesis/mock/cache/GetRecordsTests.scala
+++ b/src/test/scala/kinesis/mock/cache/GetRecordsTests.scala
@@ -43,7 +43,7 @@ class GetRecordsTests
           putRecordRequestArb.arbitrary
             .take(5)
             .toVector
-            .map(_.copy(streamName = streamName))
+            .map(_.copy(streamName = Some(streamName), streamArn = None))
         )
         _ <- recordRequests.traverse(req =>
           cache.putRecord(req, context, false, Some(awsRegion)).rethrow

--- a/src/test/scala/kinesis/mock/cache/PersistenceTests.scala
+++ b/src/test/scala/kinesis/mock/cache/PersistenceTests.scala
@@ -56,7 +56,7 @@ class PersistenceTests
           putRecordRequestArb.arbitrary
             .take(5)
             .toVector
-            .map(_.copy(streamName = streamName))
+            .map(_.copy(streamName = Some(streamName), streamArn = None))
         )
         _ <- recordRequests.traverse(req =>
           cache.putRecord(req, context, false, Some(awsRegion)).rethrow

--- a/src/test/scala/kinesis/mock/cache/PutRecordTests.scala
+++ b/src/test/scala/kinesis/mock/cache/PutRecordTests.scala
@@ -44,7 +44,7 @@ class PutRecordTests
           putRecordRequestArb.arbitrary
             .take(5)
             .toVector
-            .map(_.copy(streamName = streamName))
+            .map(_.copy(streamName = Some(streamName), streamArn = None))
         )
         _ <- recordRequests.traverse(req =>
           cache.putRecord(req, context, false, Some(awsRegion)).rethrow

--- a/src/test/scala/kinesis/mock/cache/PutRecordsTests.scala
+++ b/src/test/scala/kinesis/mock/cache/PutRecordsTests.scala
@@ -45,7 +45,8 @@ class PutRecordsTests
             putRecordsRequestEntryArb.arbitrary
               .take(5)
               .toVector,
-            streamName
+            Some(streamName),
+            None
           )
         )
         _ <- cache.putRecords(req, context, false, Some(awsRegion)).rethrow

--- a/src/test/scala/kinesis/mock/instances/arbitrary.scala
+++ b/src/test/scala/kinesis/mock/instances/arbitrary.scala
@@ -751,13 +751,18 @@ object arbitrary {
       explicitHashKey <- Gen.option(explicitHashKeyGen)
       partitionKey <- partitionKeyGen
       sequenceNumberForOrdering <- Gen.option(sequenceNumberArbitrary.arbitrary)
-      streamName <- streamNameGen
+      nameOrArn <- Gen.choose(1, 2)
+      streamName <-
+        if (nameOrArn == 1) streamNameGen.map(Some(_)) else Gen.const(None)
+      streamArn <-
+        if (nameOrArn == 2) streamArnGen.map(Some(_)) else Gen.const(None)
     } yield PutRecordRequest(
       data,
       explicitHashKey,
       partitionKey,
       sequenceNumberForOrdering,
-      streamName
+      streamName,
+      streamArn
     )
   )
 
@@ -785,8 +790,12 @@ object arbitrary {
         recordsSize,
         putRecordsRequestEntryArb.arbitrary
       )
-      streamName <- streamNameGen
-    } yield PutRecordsRequest(records, streamName)
+      nameOrArn <- Gen.choose(1, 2)
+      streamName <-
+        if (nameOrArn == 1) streamNameGen.map(Some(_)) else Gen.const(None)
+      streamArn <-
+        if (nameOrArn == 2) streamArnGen.map(Some(_)) else Gen.const(None)
+    } yield PutRecordsRequest(records, streamName, streamArn)
   )
 
   implicit val putRecordsResultEntry: Arbitrary[PutRecordsResultEntry] =


### PR DESCRIPTION
## Changes Introduced

AWS has introduced the StreamARN parameter for PutRecord and PutRecords. Recently the KPL was upgraded in the 0.15.x release to leverage the StreamARN parameter via STS. This was failing in the scala-steward branch as a result. 

## Applicable linked issues

## Checklist (check all that apply)

- [X] This change maintains backwards compatibility
- [X] I have introduced tests for all new features and changes
- [ ] I have added documentation covering all new features and changes
- [X] This pull-request is ready for review