### PR TITLE
Allow GetRecords to consume closed shards + StreamARN support

### DIFF
--- a/src/fun/scala/kinesis/mock/KCLRecordProcessor.scala
+++ b/src/fun/scala/kinesis/mock/KCLRecordProcessor.scala
@@ -21,15 +21,16 @@ case class KCLRecordProcessor(
     .asScala
     .toVector
     .traverse_(record =>
-      resultsQueue.offer(record) *> IO(
+      resultsQueue.offer(record) *> IO.blocking(
         x.checkpointer()
           .checkpoint(record.sequenceNumber(), record.subSequenceNumber())
       )
     )
     .unsafeRunSync()
   override def leaseLost(x: LeaseLostInput): Unit = ()
-  override def shardEnded(x: ShardEndedInput): Unit =
+  override def shardEnded(x: ShardEndedInput): Unit = {
     x.checkpointer().checkpoint()
+  }
   override def shutdownRequested(x: ShutdownRequestedInput): Unit = ()
 }
 

--- a/src/fun/scala/kinesis/mock/KCLRecordProcessor.scala
+++ b/src/fun/scala/kinesis/mock/KCLRecordProcessor.scala
@@ -28,7 +28,8 @@ case class KCLRecordProcessor(
     )
     .unsafeRunSync()
   override def leaseLost(x: LeaseLostInput): Unit = ()
-  override def shardEnded(x: ShardEndedInput): Unit = ()
+  override def shardEnded(x: ShardEndedInput): Unit =
+    x.checkpointer().checkpoint()
   override def shutdownRequested(x: ShutdownRequestedInput): Unit = ()
 }
 

--- a/src/fun/scala/kinesis/mock/KCLTests.scala
+++ b/src/fun/scala/kinesis/mock/KCLTests.scala
@@ -145,6 +145,20 @@ class KCLTests extends AwsFunctionalTests {
         .build()
     )
     _ <- resources.functionalTestResources.logger.debug(
+      s"Scaling stream ${resources.functionalTestResources.streamName}"
+    )
+    _ <- resources.functionalTestResources.kinesisClient
+      .updateShardCount(
+        UpdateShardCountRequest
+          .builder()
+          .streamName(resources.functionalTestResources.streamName.streamName)
+          .targetShardCount(2)
+          .scalingType(ScalingType.UNIFORM_SCALING)
+          .build()
+      )
+      .toIO
+    _ <- IO.sleep(2.seconds)
+    _ <- resources.functionalTestResources.logger.debug(
       s"Putting records to ${resources.functionalTestResources.streamName}"
     )
     _ <- resources.functionalTestResources.kinesisClient.putRecords(req).toIO

--- a/src/fun/scala/kinesis/mock/KCLTests.scala
+++ b/src/fun/scala/kinesis/mock/KCLTests.scala
@@ -115,7 +115,7 @@ class KCLTests extends AwsFunctionalTests {
               )
           )(x =>
             resources.logger.debug("Shutting down KCL Scheduler") >>
-              scheduler.startGracefulShutdown().toIO >>
+              IO.blocking(scheduler.shutdown()) >>
               x.join.void >>
               resources.logger.debug("KCL Scheduler has been shut down")
           )

--- a/src/fun/scala/kinesis/mock/ListShardsTests.scala
+++ b/src/fun/scala/kinesis/mock/ListShardsTests.scala
@@ -34,7 +34,7 @@ class ListShardsTests extends AwsFunctionalTests {
         )
         .toIO
     } yield assert(
-      res.shards().size() == 5,
+      res.shards().size() == 4,
       s"$res"
     )
   }

--- a/src/main/scala/kinesis/mock/KinesisMockService.scala
+++ b/src/main/scala/kinesis/mock/KinesisMockService.scala
@@ -104,7 +104,7 @@ object KinesisMockService extends IOApp {
         streamName: StreamName,
         region: AwsRegion
     ): IO[Boolean] = {
-      val descReq = DescribeStreamSummaryRequest(streamName)
+      val descReq = DescribeStreamSummaryRequest(Some(streamName), None)
       cache
         .describeStreamSummary(descReq, context, isCbor = false, Some(region))
         .map {

--- a/src/main/scala/kinesis/mock/api/DecreaseStreamRetentionPeriodRequest.scala
+++ b/src/main/scala/kinesis/mock/api/DecreaseStreamRetentionPeriodRequest.scala
@@ -15,40 +15,44 @@ import kinesis.mock.validations.CommonValidations
 // https://docs.aws.amazon.com/kinesis/latest/APIReference/API_DecreaseStreamRetention.html
 final case class DecreaseStreamRetentionPeriodRequest(
     retentionPeriodHours: Int,
-    streamName: StreamName
+    streamName: Option[StreamName],
+    streamArn: Option[StreamArn]
 ) {
   def decreaseStreamRetention(
       streamsRef: Ref[IO, Streams],
       awsRegion: AwsRegion,
       awsAccountId: AwsAccountId
   ): IO[Response[Unit]] = streamsRef.modify { streams =>
-    val streamArn = StreamArn(awsRegion, streamName, awsAccountId)
     CommonValidations
-      .validateStreamName(streamName)
-      .flatMap(_ =>
+      .getStreamNameArn(streamName, streamArn, awsRegion, awsAccountId)
+      .flatMap { case (name, arn) =>
         CommonValidations
-          .findStream(streamArn, streams)
-          .flatMap(stream =>
-            (
-              CommonValidations
-                .validateRetentionPeriodHours(retentionPeriodHours),
-              CommonValidations.isStreamActive(streamArn, streams),
-              if (stream.retentionPeriod.toHours < retentionPeriodHours)
-                InvalidArgumentException(
-                  s"Provided RetentionPeriodHours $retentionPeriodHours is greater than the currently defined retention period ${stream.retentionPeriod.toHours}"
-                ).asLeft
-              else Right(())
-            ).mapN((_, _, _) => stream)
+          .validateStreamName(name)
+          .flatMap(_ =>
+            CommonValidations
+              .findStream(arn, streams)
+              .flatMap(stream =>
+                (
+                  CommonValidations
+                    .validateRetentionPeriodHours(retentionPeriodHours),
+                  CommonValidations.isStreamActive(arn, streams),
+                  if (stream.retentionPeriod.toHours < retentionPeriodHours)
+                    InvalidArgumentException(
+                      s"Provided RetentionPeriodHours $retentionPeriodHours is greater than the currently defined retention period ${stream.retentionPeriod.toHours}"
+                    ).asLeft
+                  else Right(())
+                ).mapN((_, _, _) => stream)
+              )
           )
-      )
-      .map(stream =>
-        (
-          streams.updateStream(
-            stream.copy(retentionPeriod = retentionPeriodHours.hours)
-          ),
-          ()
-        )
-      )
+          .map(stream =>
+            (
+              streams.updateStream(
+                stream.copy(retentionPeriod = retentionPeriodHours.hours)
+              ),
+              ()
+            )
+          )
+      }
       .sequenceWithDefault(streams)
   }
 }
@@ -56,17 +60,21 @@ final case class DecreaseStreamRetentionPeriodRequest(
 object DecreaseStreamRetentionPeriodRequest {
   implicit val decreaseStreamRetentionPeriodRequestCirceEncoder
       : circe.Encoder[DecreaseStreamRetentionPeriodRequest] =
-    circe.Encoder.forProduct2("RetentionPeriodHours", "StreamName")(x =>
-      (x.retentionPeriodHours, x.streamName)
-    )
+    circe.Encoder.forProduct3(
+      "RetentionPeriodHours",
+      "StreamName",
+      "StreamARN"
+    )(x => (x.retentionPeriodHours, x.streamName, x.streamArn))
   implicit val decreaseStreamRetentionPeriodRequestCirceDecoder
       : circe.Decoder[DecreaseStreamRetentionPeriodRequest] = { x =>
     for {
       retentionPeriodHours <- x.downField("RetentionPeriodHours").as[Int]
-      streamName <- x.downField("StreamName").as[StreamName]
+      streamName <- x.downField("StreamName").as[Option[StreamName]]
+      streamArn <- x.downField("StreamARN").as[Option[StreamArn]]
     } yield DecreaseStreamRetentionPeriodRequest(
       retentionPeriodHours,
-      streamName
+      streamName,
+      streamArn
     )
   }
   implicit val decreaseStreamRetentionPeriodRequestEncoder

--- a/src/main/scala/kinesis/mock/api/DisableEnhancedMonitoringResponse.scala
+++ b/src/main/scala/kinesis/mock/api/DisableEnhancedMonitoringResponse.scala
@@ -9,18 +9,25 @@ import kinesis.mock.models._
 final case class DisableEnhancedMonitoringResponse(
     currentShardLevelMetrics: Vector[ShardLevelMetric],
     desiredShardLevelMetrics: Vector[ShardLevelMetric],
-    streamName: StreamName
+    streamName: StreamName,
+    streamArn: StreamArn
 )
 
 object DisableEnhancedMonitoringResponse {
   implicit val disableEnhancedMonitoringResponseCirceEncoder
       : circe.Encoder[DisableEnhancedMonitoringResponse] =
-    circe.Encoder.forProduct3(
+    circe.Encoder.forProduct4(
       "CurrentShardLevelMetrics",
       "DesiredShardLevelMetrics",
-      "StreamName"
+      "StreamName",
+      "StreamARN"
     )(x =>
-      (x.currentShardLevelMetrics, x.desiredShardLevelMetrics, x.streamName)
+      (
+        x.currentShardLevelMetrics,
+        x.desiredShardLevelMetrics,
+        x.streamName,
+        x.streamArn
+      )
     )
 
   implicit val disableEnhancedMonitoringResponseCirceDecoder
@@ -33,10 +40,12 @@ object DisableEnhancedMonitoringResponse {
         .downField("DesiredShardLevelMetrics")
         .as[Vector[ShardLevelMetric]]
       streamName <- x.downField("StreamName").as[StreamName]
+      streamArn <- x.downField("StreamARN").as[StreamArn]
     } yield DisableEnhancedMonitoringResponse(
       currentShardLevelMetrics,
       desiredShardLevelMetrics,
-      streamName
+      streamName,
+      streamArn
     )
   }
   implicit val disableEnhancedMonitoringResponseEncoder

--- a/src/main/scala/kinesis/mock/api/EnableEnhancedMonitoringResponse.scala
+++ b/src/main/scala/kinesis/mock/api/EnableEnhancedMonitoringResponse.scala
@@ -9,18 +9,25 @@ import kinesis.mock.models._
 final case class EnableEnhancedMonitoringResponse(
     currentShardLevelMetrics: Vector[ShardLevelMetric],
     desiredShardLevelMetrics: Vector[ShardLevelMetric],
-    streamName: StreamName
+    streamName: StreamName,
+    streamArn: StreamArn
 )
 
 object EnableEnhancedMonitoringResponse {
   implicit val enableEnhancedMonitoringResponseCirceEncoder
       : circe.Encoder[EnableEnhancedMonitoringResponse] =
-    circe.Encoder.forProduct3(
+    circe.Encoder.forProduct4(
       "CurrentShardLevelMetrics",
       "DesiredShardLevelMetrics",
-      "StreamName"
+      "StreamName",
+      "StreamARN"
     )(x =>
-      (x.currentShardLevelMetrics, x.desiredShardLevelMetrics, x.streamName)
+      (
+        x.currentShardLevelMetrics,
+        x.desiredShardLevelMetrics,
+        x.streamName,
+        x.streamArn
+      )
     )
 
   implicit val enableEnhancedMonitoringResponseCirceDecoder
@@ -33,10 +40,12 @@ object EnableEnhancedMonitoringResponse {
         .downField("DesiredShardLevelMetrics")
         .as[Vector[ShardLevelMetric]]
       streamName <- x.downField("StreamName").as[StreamName]
+      streamArn <- x.downField("StreamARN").as[StreamArn]
     } yield EnableEnhancedMonitoringResponse(
       currentShardLevelMetrics,
       desiredShardLevelMetrics,
-      streamName
+      streamName,
+      streamArn
     )
   }
   implicit val enableEnhancedMonitoringResponseEncoder

--- a/src/main/scala/kinesis/mock/api/GetRecordsRequest.scala
+++ b/src/main/scala/kinesis/mock/api/GetRecordsRequest.scala
@@ -29,14 +29,13 @@ final case class GetRecordsRequest(
           CommonValidations
             .findStream(streamArn, streams)
             .flatMap(stream =>
-              CommonValidations.findShard(parts.shardId, stream).flatMap { case (shard, data) =>
-                (limit match {
-                  case Some(l) => CommonValidations.validateLimit(l)
-                  case None    => Right(())
-                }).flatMap { _ =>
-                  CommonValidations
-                    .isShardOpen(shard)
-                    .flatMap { _ =>
+              CommonValidations.findShard(parts.shardId, stream).flatMap {
+                case (shard, data) =>
+                  (limit match {
+                    case Some(l) => CommonValidations.validateLimit(l)
+                    case None    => Right(())
+                  }).flatMap {
+                    _ =>
                       val allShards = stream.shards.keys.toVector
                       val childShards = allShards
                         .filter(_.parentShardId.contains(shard.shardId.shardId))
@@ -151,8 +150,8 @@ final case class GetRecordsRequest(
                           }
                         }
                       }
-                    }
-                }
+
+                  }
               }
             )
         )

--- a/src/main/scala/kinesis/mock/api/GetRecordsResponse.scala
+++ b/src/main/scala/kinesis/mock/api/GetRecordsResponse.scala
@@ -10,9 +10,9 @@ import io.circe
 import kinesis.mock.models._
 
 final case class GetRecordsResponse(
-    childShards: Vector[ChildShard],
+    childShards: Option[Vector[ChildShard]],
     millisBehindLatest: Long,
-    nextShardIterator: ShardIterator,
+    nextShardIterator: Option[ShardIterator],
     records: Queue[KinesisRecord]
 )
 
@@ -34,9 +34,11 @@ object GetRecordsResponse {
   ): circe.Decoder[GetRecordsResponse] =
     x =>
       for {
-        childShards <- x.downField("ChildShards").as[Vector[ChildShard]]
+        childShards <- x.downField("ChildShards").as[Option[Vector[ChildShard]]]
         millisBehindLatest <- x.downField("MillisBehindLatest").as[Long]
-        nextShardIterator <- x.downField("NextShardIterator").as[ShardIterator]
+        nextShardIterator <- x
+          .downField("NextShardIterator")
+          .as[Option[ShardIterator]]
         records <- x.downField("Records").as[Queue[KinesisRecord]]
       } yield GetRecordsResponse(
         childShards,

--- a/src/main/scala/kinesis/mock/api/IncreaseStreamRetentionPeriodRequest.scala
+++ b/src/main/scala/kinesis/mock/api/IncreaseStreamRetentionPeriodRequest.scala
@@ -15,40 +15,44 @@ import kinesis.mock.validations.CommonValidations
 // https://docs.aws.amazon.com/kinesis/latest/APIReference/API_IncreaseStreamRetention.html
 final case class IncreaseStreamRetentionPeriodRequest(
     retentionPeriodHours: Int,
-    streamName: StreamName
+    streamName: Option[StreamName],
+    streamArn: Option[StreamArn]
 ) {
   def increaseStreamRetention(
       streamsRef: Ref[IO, Streams],
       awsRegion: AwsRegion,
       awsAccountId: AwsAccountId
   ): IO[Response[Unit]] = streamsRef.modify { streams =>
-    val streamArn = StreamArn(awsRegion, streamName, awsAccountId)
     CommonValidations
-      .validateStreamName(streamName)
-      .flatMap(_ =>
+      .getStreamNameArn(streamName, streamArn, awsRegion, awsAccountId)
+      .flatMap { case (name, arn) =>
         CommonValidations
-          .findStream(streamArn, streams)
-          .flatMap(stream =>
-            (
-              CommonValidations
-                .validateRetentionPeriodHours(retentionPeriodHours),
-              CommonValidations.isStreamActive(streamArn, streams),
-              if (stream.retentionPeriod.toHours > retentionPeriodHours)
-                InvalidArgumentException(
-                  s"Provided RetentionPeriodHours $retentionPeriodHours is less than the currently defined retention period ${stream.retentionPeriod.toHours}"
-                ).asLeft
-              else Right(())
-            ).mapN((_, _, _) => stream)
+          .validateStreamName(name)
+          .flatMap(_ =>
+            CommonValidations
+              .findStream(arn, streams)
+              .flatMap(stream =>
+                (
+                  CommonValidations
+                    .validateRetentionPeriodHours(retentionPeriodHours),
+                  CommonValidations.isStreamActive(arn, streams),
+                  if (stream.retentionPeriod.toHours > retentionPeriodHours)
+                    InvalidArgumentException(
+                      s"Provided RetentionPeriodHours $retentionPeriodHours is less than the currently defined retention period ${stream.retentionPeriod.toHours}"
+                    ).asLeft
+                  else Right(())
+                ).mapN((_, _, _) => stream)
+              )
           )
-      )
-      .map(stream =>
-        (
-          streams.updateStream(
-            stream.copy(retentionPeriod = retentionPeriodHours.hours)
-          ),
-          ()
-        )
-      )
+          .map(stream =>
+            (
+              streams.updateStream(
+                stream.copy(retentionPeriod = retentionPeriodHours.hours)
+              ),
+              ()
+            )
+          )
+      }
       .sequenceWithDefault(streams)
   }
 }
@@ -56,17 +60,21 @@ final case class IncreaseStreamRetentionPeriodRequest(
 object IncreaseStreamRetentionPeriodRequest {
   implicit val increaseStreamRetentionRequestCirceEncoder
       : circe.Encoder[IncreaseStreamRetentionPeriodRequest] =
-    circe.Encoder.forProduct2("RetentionPeriodHours", "StreamName")(x =>
-      (x.retentionPeriodHours, x.streamName)
-    )
+    circe.Encoder.forProduct3(
+      "RetentionPeriodHours",
+      "StreamName",
+      "StreamARN"
+    )(x => (x.retentionPeriodHours, x.streamName, x.streamArn))
   implicit val increaseStreamRetentionRequestCirceDecoder
       : circe.Decoder[IncreaseStreamRetentionPeriodRequest] = { x =>
     for {
       retentionPeriodHours <- x.downField("RetentionPeriodHours").as[Int]
-      streamName <- x.downField("StreamName").as[StreamName]
+      streamName <- x.downField("StreamName").as[Option[StreamName]]
+      streamArn <- x.downField("StreamARN").as[Option[StreamArn]]
     } yield IncreaseStreamRetentionPeriodRequest(
       retentionPeriodHours,
-      streamName
+      streamName,
+      streamArn
     )
   }
   implicit val increaseStreamRetentionRequestEncoder

--- a/src/main/scala/kinesis/mock/api/MergeShardsRequest.scala
+++ b/src/main/scala/kinesis/mock/api/MergeShardsRequest.scala
@@ -123,14 +123,10 @@ object MergeShardsRequest {
       None,
       now,
       HashKeyRange(
-        Math.max(
-          adjacentShard.hashKeyRange.endingHashKey.toLong,
-          shard.hashKeyRange.endingHashKey.toLong
-        ),
-        Math.min(
-          adjacentShard.hashKeyRange.startingHashKey.toLong,
-          shard.hashKeyRange.startingHashKey.toLong
-        )
+        adjacentShard.hashKeyRange.endingHashKey
+          .max(shard.hashKeyRange.endingHashKey),
+        adjacentShard.hashKeyRange.startingHashKey
+          .min(shard.hashKeyRange.startingHashKey)
       ),
       Some(shard.shardId.shardId),
       SequenceNumberRange(

--- a/src/main/scala/kinesis/mock/api/MergeShardsRequest.scala
+++ b/src/main/scala/kinesis/mock/api/MergeShardsRequest.scala
@@ -16,121 +16,135 @@ import kinesis.mock.validations.CommonValidations
 final case class MergeShardsRequest(
     adjacentShardToMerge: String,
     shardToMerge: String,
-    streamName: StreamName
+    streamName: Option[StreamName],
+    streamArn: Option[StreamArn]
 ) {
   def mergeShards(
       streamsRef: Ref[IO, Streams],
       awsRegion: AwsRegion,
       awsAccountId: AwsAccountId
   ): IO[Response[Unit]] = {
-    val streamArn = StreamArn(awsRegion, streamName, awsAccountId)
     streamsRef.modify(streams =>
       CommonValidations
-        .validateStreamName(streamName)
-        .flatMap(_ =>
+        .getStreamNameArn(streamName, streamArn, awsRegion, awsAccountId)
+        .flatMap { case (name, arn) =>
           CommonValidations
-            .findStream(streamArn, streams)
-            .flatMap { stream =>
-              (
-                CommonValidations.isStreamActive(streamArn, streams),
-                CommonValidations.validateShardId(shardToMerge),
-                CommonValidations.validateShardId(adjacentShardToMerge),
-                CommonValidations
-                  .findShard(adjacentShardToMerge, stream)
-                  .flatMap { case (adjacentShard, adjacentData) =>
-                    CommonValidations.isShardOpen(adjacentShard).flatMap { _ =>
-                      CommonValidations
-                        .findShard(shardToMerge, stream)
-                        .flatMap { case (shard, shardData) =>
-                          CommonValidations.isShardOpen(shard).flatMap { _ =>
-                            if (
-                              adjacentShard.hashKeyRange
-                                .isAdjacent(shard.hashKeyRange)
-                            )
-                              Right(
-                                (
-                                  (adjacentShard, adjacentData),
-                                  (shard, shardData)
-                                )
-                              )
-                            else
-                              InvalidArgumentException(
-                                "Provided shards are not adjacent"
-                              ).asLeft
-                          }
+            .validateStreamName(name)
+            .flatMap(_ =>
+              CommonValidations
+                .findStream(arn, streams)
+                .flatMap { stream =>
+                  (
+                    CommonValidations.isStreamActive(arn, streams),
+                    CommonValidations.validateShardId(shardToMerge),
+                    CommonValidations.validateShardId(adjacentShardToMerge),
+                    CommonValidations
+                      .findShard(adjacentShardToMerge, stream)
+                      .flatMap { case (adjacentShard, adjacentData) =>
+                        CommonValidations.isShardOpen(adjacentShard).flatMap {
+                          _ =>
+                            CommonValidations
+                              .findShard(shardToMerge, stream)
+                              .flatMap { case (shard, shardData) =>
+                                CommonValidations.isShardOpen(shard).flatMap {
+                                  _ =>
+                                    if (
+                                      adjacentShard.hashKeyRange
+                                        .isAdjacent(shard.hashKeyRange)
+                                    )
+                                      Right(
+                                        (
+                                          (adjacentShard, adjacentData),
+                                          (shard, shardData)
+                                        )
+                                      )
+                                    else
+                                      InvalidArgumentException(
+                                        "Provided shards are not adjacent"
+                                      ).asLeft
+                                }
+                              }
                         }
-                    }
+                      }
+                  ).mapN {
+                    case (
+                          _,
+                          _,
+                          _,
+                          ((adjacentShard, adjacentData), (shard, shardData))
+                        ) =>
+                      (
+                        stream,
+                        (adjacentShard, adjacentData),
+                        (shard, shardData)
+                      )
                   }
-              ).mapN {
-                case (
-                      _,
-                      _,
-                      _,
-                      ((adjacentShard, adjacentData), (shard, shardData))
-                    ) =>
-                  (stream, (adjacentShard, adjacentData), (shard, shardData))
-              }
-            }
-        )
-        .map {
-          case (
-                stream,
-                (adjacentShard, adjacentData),
-                (shard, shardData)
-              ) =>
-            val now = Instant.now()
-            val newShardIndex =
-              stream.shards.keys.map(_.shardId.index).max + 1
-            val newShard: (Shard, Vector[KinesisRecord]) = Shard(
-              Some(adjacentShard.shardId.shardId),
-              None,
-              now,
-              HashKeyRange(
-                Math.max(
-                  adjacentShard.hashKeyRange.endingHashKey.toLong,
-                  shard.hashKeyRange.endingHashKey.toLong
-                ),
-                Math.min(
-                  adjacentShard.hashKeyRange.startingHashKey.toLong,
-                  shard.hashKeyRange.startingHashKey.toLong
-                )
-              ),
-              Some(shard.shardId.shardId),
-              SequenceNumberRange(
-                None,
-                if (
-                  adjacentShard.sequenceNumberRange.startingSequenceNumber.numericValue < shard.sequenceNumberRange.startingSequenceNumber.numericValue
-                )
-                  adjacentShard.sequenceNumberRange.startingSequenceNumber
-                else shard.sequenceNumberRange.startingSequenceNumber
-              ),
-              ShardId.create(newShardIndex)
-            ) -> Vector.empty
+                }
+            )
+            .map {
+              case (
+                    stream,
+                    (adjacentShard, adjacentData),
+                    (shard, shardData)
+                  ) =>
+                val now = Instant.now()
+                val newShardIndex =
+                  stream.shards.keys.map(_.shardId.index).max + 1
+                val newShard: (Shard, Vector[KinesisRecord]) = Shard(
+                  Some(adjacentShard.shardId.shardId),
+                  None,
+                  now,
+                  HashKeyRange(
+                    Math.max(
+                      adjacentShard.hashKeyRange.endingHashKey.toLong,
+                      shard.hashKeyRange.endingHashKey.toLong
+                    ),
+                    Math.min(
+                      adjacentShard.hashKeyRange.startingHashKey.toLong,
+                      shard.hashKeyRange.startingHashKey.toLong
+                    )
+                  ),
+                  Some(shard.shardId.shardId),
+                  SequenceNumberRange(
+                    None,
+                    if (
+                      adjacentShard.sequenceNumberRange.startingSequenceNumber.numericValue < shard.sequenceNumberRange.startingSequenceNumber.numericValue
+                    )
+                      adjacentShard.sequenceNumberRange.startingSequenceNumber
+                    else shard.sequenceNumberRange.startingSequenceNumber
+                  ),
+                  ShardId.create(newShardIndex)
+                ) -> Vector.empty
 
-            val oldShards: Vector[(Shard, Vector[KinesisRecord])] = Vector(
-              adjacentShard.copy(
-                closedTimestamp = Some(now),
-                sequenceNumberRange = adjacentShard.sequenceNumberRange
-                  .copy(endingSequenceNumber = Some(SequenceNumber.shardEnd))
-              ) -> adjacentData,
-              shard.copy(
-                closedTimestamp = Some(now),
-                sequenceNumberRange = shard.sequenceNumberRange
-                  .copy(endingSequenceNumber = Some(SequenceNumber.shardEnd))
-              ) -> shardData
-            )
-            (
-              streams.updateStream(
-                stream.copy(
-                  shards = stream.shards.filterNot { case (s, _) =>
-                    s.shardId == adjacentShard.shardId || s.shardId == shard.shardId
-                  }
-                    ++ (oldShards :+ newShard),
-                  streamStatus = StreamStatus.UPDATING
+                val oldShards: Vector[(Shard, Vector[KinesisRecord])] = Vector(
+                  adjacentShard.copy(
+                    closedTimestamp = Some(now),
+                    sequenceNumberRange = adjacentShard.sequenceNumberRange
+                      .copy(endingSequenceNumber =
+                        Some(SequenceNumber.shardEnd)
+                      )
+                  ) -> adjacentData,
+                  shard.copy(
+                    closedTimestamp = Some(now),
+                    sequenceNumberRange = shard.sequenceNumberRange
+                      .copy(endingSequenceNumber =
+                        Some(SequenceNumber.shardEnd)
+                      )
+                  ) -> shardData
                 )
-              ),
-              ()
-            )
+                (
+                  streams.updateStream(
+                    stream.copy(
+                      shards = stream.shards.filterNot { case (s, _) =>
+                        s.shardId == adjacentShard.shardId || s.shardId == shard.shardId
+                      }
+                        ++ (oldShards :+ newShard),
+                      streamStatus = StreamStatus.UPDATING
+                    )
+                  ),
+                  ()
+                )
+            }
         }
         .sequenceWithDefault(streams)
     )
@@ -140,11 +154,12 @@ final case class MergeShardsRequest(
 object MergeShardsRequest {
   implicit val mergeShardsRequestCirceEncoder
       : circe.Encoder[MergeShardsRequest] =
-    circe.Encoder.forProduct3(
+    circe.Encoder.forProduct4(
       "AdjacentShardToMerge",
       "ShardToMerge",
-      "StreamName"
-    )(x => (x.adjacentShardToMerge, x.shardToMerge, x.streamName))
+      "StreamName",
+      "StreamARN"
+    )(x => (x.adjacentShardToMerge, x.shardToMerge, x.streamName, x.streamArn))
 
   implicit val mergeShardsRequestCirceDecoder
       : circe.Decoder[MergeShardsRequest] =
@@ -152,8 +167,14 @@ object MergeShardsRequest {
       for {
         adjacentShardToMerge <- x.downField("AdjacentShardToMerge").as[String]
         shardToMerge <- x.downField("ShardToMerge").as[String]
-        streamName <- x.downField("StreamName").as[StreamName]
-      } yield MergeShardsRequest(adjacentShardToMerge, shardToMerge, streamName)
+        streamName <- x.downField("StreamName").as[Option[StreamName]]
+        streamArn <- x.downField("StreamARN").as[Option[StreamArn]]
+      } yield MergeShardsRequest(
+        adjacentShardToMerge,
+        shardToMerge,
+        streamName,
+        streamArn
+      )
   implicit val mergeShardsRequestEncoder: Encoder[MergeShardsRequest] =
     Encoder.derive
   implicit val mergeShardsRequestDecoder: Decoder[MergeShardsRequest] =

--- a/src/main/scala/kinesis/mock/api/RemoveTagsFromStreamRequest.scala
+++ b/src/main/scala/kinesis/mock/api/RemoveTagsFromStreamRequest.scala
@@ -11,7 +11,8 @@ import kinesis.mock.syntax.either._
 import kinesis.mock.validations.CommonValidations
 
 final case class RemoveTagsFromStreamRequest(
-    streamName: StreamName,
+    streamName: Option[StreamName],
+    streamArn: Option[StreamArn],
     tagKeys: Vector[String]
 ) {
   // https://docs.aws.amazon.com/kinesis/latest/APIReference/API_RemoveTagsFromStream.html
@@ -22,32 +23,36 @@ final case class RemoveTagsFromStreamRequest(
       awsRegion: AwsRegion,
       awsAccountId: AwsAccountId
   ): IO[Response[Unit]] = {
-    val streamArn = StreamArn(awsRegion, streamName, awsAccountId)
     streamsRef.modify(streams =>
       CommonValidations
-        .validateStreamName(streamName)
-        .flatMap(_ =>
+        .getStreamNameArn(streamName, streamArn, awsRegion, awsAccountId)
+        .flatMap { case (name, arn) =>
           CommonValidations
-            .findStream(streamArn, streams)
-            .flatMap(stream =>
-              (
-                CommonValidations.validateTagKeys(tagKeys), {
-                  val numberOfTags = tagKeys.length
-                  if (numberOfTags > 10)
-                    InvalidArgumentException(
-                      s"Can only remove 50 tags with a single request. Request contains $numberOfTags tags"
-                    ).asLeft
-                  else Right(())
-                }
-              ).mapN((_, _) => stream)
+            .validateStreamName(name)
+            .flatMap(_ =>
+              CommonValidations
+                .findStream(arn, streams)
+                .flatMap(stream =>
+                  (
+                    CommonValidations.validateTagKeys(tagKeys), {
+                      val numberOfTags = tagKeys.length
+                      if (numberOfTags > 10)
+                        InvalidArgumentException(
+                          s"Can only remove 50 tags with a single request. Request contains $numberOfTags tags"
+                        ).asLeft
+                      else Right(())
+                    }
+                  ).mapN((_, _) => stream)
+                )
             )
-        )
-        .map(stream =>
-          (
-            streams.updateStream(stream.copy(tags = stream.tags -- tagKeys)),
-            ()
-          )
-        )
+            .map(stream =>
+              (
+                streams
+                  .updateStream(stream.copy(tags = stream.tags -- tagKeys)),
+                ()
+              )
+            )
+        }
         .sequenceWithDefault(streams)
     )
   }
@@ -56,15 +61,16 @@ final case class RemoveTagsFromStreamRequest(
 object RemoveTagsFromStreamRequest {
   implicit val removeTagsFromStreamRequestCirceEncoder
       : circe.Encoder[RemoveTagsFromStreamRequest] =
-    circe.Encoder.forProduct2("StreamName", "TagKeys")(x =>
-      (x.streamName, x.tagKeys)
+    circe.Encoder.forProduct3("StreamName", "StreamARN", "TagKeys")(x =>
+      (x.streamName, x.streamArn, x.tagKeys)
     )
   implicit val removeTagsFromStreamRequestCirceDecoder
       : circe.Decoder[RemoveTagsFromStreamRequest] = { x =>
     for {
-      streamName <- x.downField("StreamName").as[StreamName]
+      streamName <- x.downField("StreamName").as[Option[StreamName]]
+      streamArn <- x.downField("StreamARN").as[Option[StreamArn]]
       tagKeys <- x.downField("TagKeys").as[Vector[String]]
-    } yield RemoveTagsFromStreamRequest(streamName, tagKeys)
+    } yield RemoveTagsFromStreamRequest(streamName, streamArn, tagKeys)
   }
   implicit val removeTagsFromStreamRequestEncoder
       : Encoder[RemoveTagsFromStreamRequest] = Encoder.derive

--- a/src/main/scala/kinesis/mock/api/SplitShardRequest.scala
+++ b/src/main/scala/kinesis/mock/api/SplitShardRequest.scala
@@ -16,7 +16,8 @@ import kinesis.mock.validations.CommonValidations
 final case class SplitShardRequest(
     newStartingHashKey: String,
     shardToSplit: String,
-    streamName: StreamName
+    streamName: Option[StreamName],
+    streamArn: Option[StreamArn]
 ) {
   def splitShard(
       streamsRef: Ref[IO, Streams],
@@ -25,104 +26,111 @@ final case class SplitShardRequest(
       awsAccountId: AwsAccountId
   ): IO[Response[Unit]] =
     streamsRef.modify { streams =>
-      val streamArn = StreamArn(awsRegion, streamName, awsAccountId)
       CommonValidations
-        .validateStreamName(streamName)
-        .flatMap(_ =>
+        .getStreamNameArn(streamName, streamArn, awsRegion, awsAccountId)
+        .flatMap { case (name, arn) =>
           CommonValidations
-            .findStream(streamArn, streams)
-            .flatMap { stream =>
-              (
-                CommonValidations.isStreamActive(streamArn, streams),
-                CommonValidations.validateShardId(shardToSplit),
-                if (!newStartingHashKey.matches("0|([1-9]\\d{0,38})")) {
-                  InvalidArgumentException(
-                    "NewStartingHashKey contains invalid characters"
-                  ).asLeft
-                } else Right(newStartingHashKey),
-                if (
-                  streams.streams.values.map(_.shards.size).sum + 1 > shardLimit
-                )
-                  LimitExceededException(
-                    "Operation would exceed the configured shard limit for the account"
-                  ).asLeft
-                else Right(()),
-                CommonValidations.findShard(shardToSplit, stream).flatMap {
-                  case (shard, shardData) =>
-                    CommonValidations.isShardOpen(shard).flatMap { _ =>
-                      val newStartingHashKeyNumber = BigInt(newStartingHashKey)
-                      if (
-                        newStartingHashKeyNumber >= shard.hashKeyRange.startingHashKey && newStartingHashKeyNumber <= shard.hashKeyRange.endingHashKey
-                      )
-                        Right((shard, shardData))
-                      else
-                        InvalidArgumentException(
-                          s"NewStartingHashKey is not within the hash range shard ${shard.shardId}"
-                        ).asLeft
+            .validateStreamName(name)
+            .flatMap(_ =>
+              CommonValidations
+                .findStream(arn, streams)
+                .flatMap { stream =>
+                  (
+                    CommonValidations.isStreamActive(arn, streams),
+                    CommonValidations.validateShardId(shardToSplit),
+                    if (!newStartingHashKey.matches("0|([1-9]\\d{0,38})")) {
+                      InvalidArgumentException(
+                        "NewStartingHashKey contains invalid characters"
+                      ).asLeft
+                    } else Right(newStartingHashKey),
+                    if (
+                      streams.streams.values
+                        .map(_.shards.size)
+                        .sum + 1 > shardLimit
+                    )
+                      LimitExceededException(
+                        "Operation would exceed the configured shard limit for the account"
+                      ).asLeft
+                    else Right(()),
+                    CommonValidations.findShard(shardToSplit, stream).flatMap {
+                      case (shard, shardData) =>
+                        CommonValidations.isShardOpen(shard).flatMap { _ =>
+                          val newStartingHashKeyNumber =
+                            BigInt(newStartingHashKey)
+                          if (
+                            newStartingHashKeyNumber >= shard.hashKeyRange.startingHashKey && newStartingHashKeyNumber <= shard.hashKeyRange.endingHashKey
+                          )
+                            Right((shard, shardData))
+                          else
+                            InvalidArgumentException(
+                              s"NewStartingHashKey is not within the hash range shard ${shard.shardId}"
+                            ).asLeft
+                        }
                     }
+                  ).mapN { case (_, _, _, _, (shard, shardData)) =>
+                    (shard, shardData, stream)
+                  }
                 }
-              ).mapN { case (_, _, _, _, (shard, shardData)) =>
-                (shard, shardData, stream)
-              }
-            }
-        )
-        .map { case (shard, shardData, stream) =>
-          val now = Instant.now()
-          val newStartingHashKeyNumber = BigInt(newStartingHashKey)
-          val newShardIndex1 = stream.shards.keys.map(_.shardId.index).max + 1
-          val newShardIndex2 = newShardIndex1 + 1
-          val newShard1: (Shard, Vector[KinesisRecord]) = Shard(
-            None,
-            None,
-            now,
-            HashKeyRange(
-              startingHashKey = shard.hashKeyRange.startingHashKey,
-              endingHashKey = newStartingHashKeyNumber - BigInt(1)
-            ),
-            Some(shard.shardId.shardId),
-            SequenceNumberRange(
-              None,
-              SequenceNumber.create(now, newShardIndex1, None, None, None)
-            ),
-            ShardId.create(newShardIndex1)
-          ) -> Vector.empty
-
-          val newShard2: (Shard, Vector[KinesisRecord]) = Shard(
-            None,
-            None,
-            now,
-            HashKeyRange(
-              startingHashKey = newStartingHashKeyNumber,
-              endingHashKey = shard.hashKeyRange.endingHashKey
-            ),
-            Some(shard.shardId.shardId),
-            SequenceNumberRange(
-              None,
-              SequenceNumber.create(now, newShardIndex2, None, None, None)
-            ),
-            ShardId.create(newShardIndex2)
-          ) -> Vector.empty
-
-          val newShards = Vector(newShard1, newShard2)
-
-          val oldShard: (Shard, Vector[KinesisRecord]) = shard.copy(
-            closedTimestamp = Some(now),
-            sequenceNumberRange = shard.sequenceNumberRange.copy(
-              endingSequenceNumber = Some(SequenceNumber.shardEnd)
             )
-          ) -> shardData
+            .map { case (shard, shardData, stream) =>
+              val now = Instant.now()
+              val newStartingHashKeyNumber = BigInt(newStartingHashKey)
+              val newShardIndex1 =
+                stream.shards.keys.map(_.shardId.index).max + 1
+              val newShardIndex2 = newShardIndex1 + 1
+              val newShard1: (Shard, Vector[KinesisRecord]) = Shard(
+                None,
+                None,
+                now,
+                HashKeyRange(
+                  startingHashKey = shard.hashKeyRange.startingHashKey,
+                  endingHashKey = newStartingHashKeyNumber - BigInt(1)
+                ),
+                Some(shard.shardId.shardId),
+                SequenceNumberRange(
+                  None,
+                  SequenceNumber.create(now, newShardIndex1, None, None, None)
+                ),
+                ShardId.create(newShardIndex1)
+              ) -> Vector.empty
 
-          (
-            streams.updateStream(
-              stream.copy(
-                shards = stream.shards.filterNot { case (shard, _) =>
-                  shard.shardId == oldShard._1.shardId
-                } ++ (newShards :+ oldShard),
-                streamStatus = StreamStatus.UPDATING
+              val newShard2: (Shard, Vector[KinesisRecord]) = Shard(
+                None,
+                None,
+                now,
+                HashKeyRange(
+                  startingHashKey = newStartingHashKeyNumber,
+                  endingHashKey = shard.hashKeyRange.endingHashKey
+                ),
+                Some(shard.shardId.shardId),
+                SequenceNumberRange(
+                  None,
+                  SequenceNumber.create(now, newShardIndex2, None, None, None)
+                ),
+                ShardId.create(newShardIndex2)
+              ) -> Vector.empty
+
+              val newShards = Vector(newShard1, newShard2)
+
+              val oldShard: (Shard, Vector[KinesisRecord]) = shard.copy(
+                closedTimestamp = Some(now),
+                sequenceNumberRange = shard.sequenceNumberRange.copy(
+                  endingSequenceNumber = Some(SequenceNumber.shardEnd)
+                )
+              ) -> shardData
+
+              (
+                streams.updateStream(
+                  stream.copy(
+                    shards = stream.shards.filterNot { case (shard, _) =>
+                      shard.shardId == oldShard._1.shardId
+                    } ++ (newShards :+ oldShard),
+                    streamStatus = StreamStatus.UPDATING
+                  )
+                ),
+                ()
               )
-            ),
-            ()
-          )
+            }
         }
         .sequenceWithDefault(streams)
     }
@@ -130,19 +138,26 @@ final case class SplitShardRequest(
 
 object SplitShardRequest {
   implicit val splitShardRequestCirceEncoder: circe.Encoder[SplitShardRequest] =
-    circe.Encoder.forProduct3(
+    circe.Encoder.forProduct4(
       "NewStartingHashKey",
       "ShardToSplit",
-      "StreamName"
-    )(x => (x.newStartingHashKey, x.shardToSplit, x.streamName))
+      "StreamName",
+      "StreamARN"
+    )(x => (x.newStartingHashKey, x.shardToSplit, x.streamName, x.streamArn))
 
   implicit val splitShardRequestCirceDecoder: circe.Decoder[SplitShardRequest] =
     x =>
       for {
         newStartingHashKey <- x.downField("NewStartingHashKey").as[String]
         shardToSplit <- x.downField("ShardToSplit").as[String]
-        streamName <- x.downField("StreamName").as[StreamName]
-      } yield SplitShardRequest(newStartingHashKey, shardToSplit, streamName)
+        streamName <- x.downField("StreamName").as[Option[StreamName]]
+        streamArn <- x.downField("StreamARN").as[Option[StreamArn]]
+      } yield SplitShardRequest(
+        newStartingHashKey,
+        shardToSplit,
+        streamName,
+        streamArn
+      )
 
   implicit val splitShardRequestEncoder: Encoder[SplitShardRequest] =
     Encoder.derive

--- a/src/main/scala/kinesis/mock/api/StopStreamEncryptionRequest.scala
+++ b/src/main/scala/kinesis/mock/api/StopStreamEncryptionRequest.scala
@@ -13,40 +13,44 @@ import kinesis.mock.validations.CommonValidations
 final case class StopStreamEncryptionRequest(
     encryptionType: EncryptionType,
     keyId: String,
-    streamName: StreamName
+    streamName: Option[StreamName],
+    streamArn: Option[StreamArn]
 ) {
   def stopStreamEncryption(
       streamsRef: Ref[IO, Streams],
       awsRegion: AwsRegion,
       awsAccountId: AwsAccountId
   ): IO[Response[Unit]] = {
-    val streamArn = StreamArn(awsRegion, streamName, awsAccountId)
     streamsRef.modify(streams =>
       CommonValidations
-        .validateStreamName(streamName)
-        .flatMap(_ =>
+        .getStreamNameArn(streamName, streamArn, awsRegion, awsAccountId)
+        .flatMap { case (name, arn) =>
           CommonValidations
-            .findStream(streamArn, streams)
-            .flatMap(stream =>
-              (
-                CommonValidations.validateKeyId(keyId),
-                CommonValidations.isKmsEncryptionType(encryptionType),
-                CommonValidations.isStreamActive(streamArn, streams)
-              ).mapN((_, _, _) => stream)
+            .validateStreamName(name)
+            .flatMap(_ =>
+              CommonValidations
+                .findStream(arn, streams)
+                .flatMap(stream =>
+                  (
+                    CommonValidations.validateKeyId(keyId),
+                    CommonValidations.isKmsEncryptionType(encryptionType),
+                    CommonValidations.isStreamActive(arn, streams)
+                  ).mapN((_, _, _) => stream)
+                )
             )
-        )
-        .map(stream =>
-          (
-            streams.updateStream(
-              stream.copy(
-                encryptionType = EncryptionType.NONE,
-                streamStatus = StreamStatus.UPDATING,
-                keyId = None
+            .map(stream =>
+              (
+                streams.updateStream(
+                  stream.copy(
+                    encryptionType = EncryptionType.NONE,
+                    streamStatus = StreamStatus.UPDATING,
+                    keyId = None
+                  )
+                ),
+                ()
               )
-            ),
-            ()
-          )
-        )
+            )
+        }
         .sequenceWithDefault(streams)
     )
   }
@@ -55,17 +59,26 @@ final case class StopStreamEncryptionRequest(
 object StopStreamEncryptionRequest {
   implicit val stopStreamEncryptionRequestCirceEncoder
       : circe.Encoder[StopStreamEncryptionRequest] =
-    circe.Encoder.forProduct3("EncryptionType", "KeyId", "StreamName")(x =>
-      (x.encryptionType, x.keyId, x.streamName)
-    )
+    circe.Encoder.forProduct4(
+      "EncryptionType",
+      "KeyId",
+      "StreamName",
+      "StreamARN"
+    )(x => (x.encryptionType, x.keyId, x.streamName, x.streamArn))
 
   implicit val stopStreamEncryptionRequestCirceDecoder
       : circe.Decoder[StopStreamEncryptionRequest] = x =>
     for {
       encryptionType <- x.downField("EncryptionType").as[EncryptionType]
       keyId <- x.downField("KeyId").as[String]
-      streamName <- x.downField("StreamName").as[StreamName]
-    } yield StopStreamEncryptionRequest(encryptionType, keyId, streamName)
+      streamName <- x.downField("StreamName").as[Option[StreamName]]
+      streamArn <- x.downField("StreamARN").as[Option[StreamArn]]
+    } yield StopStreamEncryptionRequest(
+      encryptionType,
+      keyId,
+      streamName,
+      streamArn
+    )
 
   implicit val stopStreamEncryptionRequestEncoder
       : Encoder[StopStreamEncryptionRequest] = Encoder.derive

--- a/src/main/scala/kinesis/mock/validations/CommonValidations.scala
+++ b/src/main/scala/kinesis/mock/validations/CommonValidations.scala
@@ -12,6 +12,25 @@ import software.amazon.awssdk.utils.Md5Utils
 import kinesis.mock.models._
 
 object CommonValidations {
+  def getStreamNameArn(
+      streamName: Option[StreamName],
+      streamArn: Option[StreamArn],
+      awsRegion: AwsRegion,
+      awsAccountId: AwsAccountId
+  ): Response[(StreamName, StreamArn)] =
+    (streamName, streamArn) match {
+      case (_, Some(arn)) =>
+        Right((arn.streamName, arn))
+      case (Some(name), _) =>
+        Right((name, StreamArn(awsRegion, name, awsAccountId)))
+      case _ =>
+        Left(
+          InvalidArgumentException(
+            "Neither streamArn or streamName was provided"
+          )
+        )
+    }
+
   def validateStreamName(
       streamName: StreamName
   ): Response[StreamName] =

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -5,7 +5,7 @@
     </encoder>
   </appender>
   <logger name="kinesis.mock" level="${LOG_LEVEL:-ERROR}"/>
-  <logger name="software.amazon" level="${AWSV2_LOG_LEVEL:-ERROR}"/>
+  <logger name="software.amazon" level="${AWSV2_LOG_LEVEL:-INFO}"/>
   <root level="${ROOT_LOG_LEVEL:-ERROR}">
     <appender-ref ref="STDOUT" />
   </root>

--- a/src/test/scala/kinesis/mock/api/AddTagsToStreamTests.scala
+++ b/src/test/scala/kinesis/mock/api/AddTagsToStreamTests.scala
@@ -24,7 +24,7 @@ class AddTagsToStreamTests
 
       for {
         streamsRef <- Ref.of[IO, Streams](streams)
-        req = AddTagsToStreamRequest(streamArn.streamName, tags)
+        req = AddTagsToStreamRequest(None, Some(streamArn), tags)
         res <- req.addTagsToStream(
           streamsRef,
           streamArn.awsRegion,
@@ -57,7 +57,7 @@ class AddTagsToStreamTests
 
       for {
         streamsRef <- Ref.of[IO, Streams](streamsWithTag)
-        req = AddTagsToStreamRequest(streamArn.streamName, tags)
+        req = AddTagsToStreamRequest(None, Some(streamArn), tags)
         res <- req.addTagsToStream(
           streamsRef,
           streamArn.awsRegion,

--- a/src/test/scala/kinesis/mock/api/DecreaseStreamRetentionPeriodTests.scala
+++ b/src/test/scala/kinesis/mock/api/DecreaseStreamRetentionPeriodTests.scala
@@ -27,7 +27,7 @@ class DecreaseStreamRetentionPeriodTests
         )
       for {
         streamsRef <- Ref.of[IO, Streams](withIncreasedRetention)
-        req = DecreaseStreamRetentionPeriodRequest(24, streamArn.streamName)
+        req = DecreaseStreamRetentionPeriodRequest(24, None, Some(streamArn))
         res <- req.decreaseStreamRetention(
           streamsRef,
           streamArn.awsRegion,
@@ -53,7 +53,7 @@ class DecreaseStreamRetentionPeriodTests
 
       for {
         streamsRef <- Ref.of[IO, Streams](streams)
-        req = DecreaseStreamRetentionPeriodRequest(48, streamArn.streamName)
+        req = DecreaseStreamRetentionPeriodRequest(48, None, Some(streamArn))
         res <- req.decreaseStreamRetention(
           streamsRef,
           streamArn.awsRegion,

--- a/src/test/scala/kinesis/mock/api/DeleteStreamTests.scala
+++ b/src/test/scala/kinesis/mock/api/DeleteStreamTests.scala
@@ -25,7 +25,7 @@ class DeleteStreamTests
 
       for {
         streamsRef <- Ref.of[IO, Streams](asActive)
-        req = DeleteStreamRequest(streamArn.streamName, None)
+        req = DeleteStreamRequest(None, Some(streamArn), None)
         res <- req.deleteStream(
           streamsRef,
           streamArn.awsRegion,
@@ -46,7 +46,7 @@ class DeleteStreamTests
 
       for {
         streamsRef <- Ref.of[IO, Streams](streams)
-        req = DeleteStreamRequest(streamArn.streamName, None)
+        req = DeleteStreamRequest(None, Some(streamArn), None)
         res <- req
           .deleteStream(streamsRef, streamArn.awsRegion, streamArn.awsAccountId)
       } yield assert(
@@ -64,7 +64,7 @@ class DeleteStreamTests
 
       for {
         streamsRef <- Ref.of[IO, Streams](streams)
-        req = DeleteStreamRequest(streamArn.streamName, None)
+        req = DeleteStreamRequest(None, Some(streamArn), None)
         res <- req
           .deleteStream(streamsRef, streamArn.awsRegion, streamArn.awsAccountId)
       } yield assert(
@@ -95,7 +95,7 @@ class DeleteStreamTests
 
       for {
         streamsRef <- Ref.of[IO, Streams](withConsumers)
-        req = DeleteStreamRequest(consumerArn.streamArn.streamName, None)
+        req = DeleteStreamRequest(None, Some(consumerArn.streamArn), None)
         res <- req.deleteStream(
           streamsRef,
           consumerArn.streamArn.awsRegion,
@@ -129,7 +129,11 @@ class DeleteStreamTests
 
       for {
         streamsRef <- Ref.of[IO, Streams](withConsumers)
-        req = DeleteStreamRequest(consumerArn.streamArn.streamName, Some(false))
+        req = DeleteStreamRequest(
+          None,
+          Some(consumerArn.streamArn),
+          Some(false)
+        )
         res <- req.deleteStream(
           streamsRef,
           consumerArn.streamArn.awsRegion,

--- a/src/test/scala/kinesis/mock/api/DescribeStreamSummaryTests.scala
+++ b/src/test/scala/kinesis/mock/api/DescribeStreamSummaryTests.scala
@@ -20,7 +20,7 @@ class DescribeStreamSummaryTests
 
       for {
         streamsRef <- Ref.of[IO, Streams](streams)
-        req = DescribeStreamSummaryRequest(streamArn.streamName)
+        req = DescribeStreamSummaryRequest(None, Some(streamArn))
         res <- req.describeStreamSummary(
           streamsRef,
           streamArn.awsRegion,

--- a/src/test/scala/kinesis/mock/api/DescribeStreamTests.scala
+++ b/src/test/scala/kinesis/mock/api/DescribeStreamTests.scala
@@ -20,7 +20,7 @@ class DescribeStreamTests
 
       for {
         streamsRef <- Ref.of[IO, Streams](streams)
-        req = DescribeStreamRequest(None, None, streamArn.streamName)
+        req = DescribeStreamRequest(None, None, None, Some(streamArn))
         res <- req.describeStream(
           streamsRef,
           streamArn.awsRegion,
@@ -48,7 +48,7 @@ class DescribeStreamTests
 
       for {
         streamsRef <- Ref.of[IO, Streams](streams)
-        req = DescribeStreamRequest(None, limit, streamArn.streamName)
+        req = DescribeStreamRequest(None, limit, None, Some(streamArn))
         res <- req.describeStream(
           streamsRef,
           streamArn.awsRegion,
@@ -83,7 +83,8 @@ class DescribeStreamTests
         req = DescribeStreamRequest(
           exclusiveStartShardId,
           None,
-          streamArn.streamName
+          None,
+          Some(streamArn)
         )
         res <- req.describeStream(
           streamsRef,

--- a/src/test/scala/kinesis/mock/api/DisableEnhancedMonitoringTests.scala
+++ b/src/test/scala/kinesis/mock/api/DisableEnhancedMonitoringTests.scala
@@ -41,7 +41,8 @@ class DisableEnhancedMonitoringTests
         streamsRef <- Ref.of[IO, Streams](updated)
         req = DisableEnhancedMonitoringRequest(
           shardLevelMetrics.shardLevelMetrics,
-          streamArn.streamName
+          None,
+          Some(streamArn)
         )
         res <- req.disableEnhancedMonitoring(
           streamsRef,

--- a/src/test/scala/kinesis/mock/api/EnableEnhancedMonitoringTests.scala
+++ b/src/test/scala/kinesis/mock/api/EnableEnhancedMonitoringTests.scala
@@ -23,7 +23,8 @@ class EnableEnhancedMonitoringTests
         streamsRef <- Ref.of[IO, Streams](streams)
         req = EnableEnhancedMonitoringRequest(
           shardLevelMetrics.shardLevelMetrics,
-          streamArn.streamName
+          None,
+          Some(streamArn)
         )
         res <- req.enableEnhancedMonitoring(
           streamsRef,

--- a/src/test/scala/kinesis/mock/api/GetRecordsTests.scala
+++ b/src/test/scala/kinesis/mock/api/GetRecordsTests.scala
@@ -171,7 +171,7 @@ class GetRecordsTests
         )
         res2 <- res1
           .traverse(r =>
-            GetRecordsRequest(Some(50), r.nextShardIterator, None)
+            GetRecordsRequest(Some(50), r.nextShardIterator.orNull, None)
               .getRecords(
                 streamsRef,
                 streamArn.awsRegion,
@@ -246,7 +246,7 @@ class GetRecordsTests
         )
         res2 <- res1
           .traverse(r =>
-            GetRecordsRequest(Some(50), r.nextShardIterator, None)
+            GetRecordsRequest(Some(50), r.nextShardIterator.orNull, None)
               .getRecords(
                 streamsRef,
                 streamArn.awsRegion,

--- a/src/test/scala/kinesis/mock/api/GetRecordsTests.scala
+++ b/src/test/scala/kinesis/mock/api/GetRecordsTests.scala
@@ -53,7 +53,7 @@ class GetRecordsTests
 
       for {
         streamsRef <- Ref.of[IO, Streams](withRecords)
-        req = GetRecordsRequest(None, shardIterator)
+        req = GetRecordsRequest(None, shardIterator, None)
         res <- req.getRecords(
           streamsRef,
           streamArn.awsRegion,
@@ -108,7 +108,7 @@ class GetRecordsTests
 
       for {
         streamsRef <- Ref.of[IO, Streams](withRecords)
-        req = GetRecordsRequest(Some(50), shardIterator)
+        req = GetRecordsRequest(Some(50), shardIterator, None)
         res <- req.getRecords(
           streamsRef,
           streamArn.awsRegion,
@@ -163,7 +163,7 @@ class GetRecordsTests
 
       for {
         streamsRef <- Ref.of[IO, Streams](withRecords)
-        req1 = GetRecordsRequest(Some(50), shardIterator)
+        req1 = GetRecordsRequest(Some(50), shardIterator, None)
         res1 <- req1.getRecords(
           streamsRef,
           streamArn.awsRegion,
@@ -171,7 +171,7 @@ class GetRecordsTests
         )
         res2 <- res1
           .traverse(r =>
-            GetRecordsRequest(Some(50), r.nextShardIterator)
+            GetRecordsRequest(Some(50), r.nextShardIterator, None)
               .getRecords(
                 streamsRef,
                 streamArn.awsRegion,
@@ -238,7 +238,7 @@ class GetRecordsTests
 
       for {
         streamsRef <- Ref.of[IO, Streams](withRecords)
-        req1 = GetRecordsRequest(Some(50), shardIterator)
+        req1 = GetRecordsRequest(Some(50), shardIterator, None)
         res1 <- req1.getRecords(
           streamsRef,
           streamArn.awsRegion,
@@ -246,7 +246,7 @@ class GetRecordsTests
         )
         res2 <- res1
           .traverse(r =>
-            GetRecordsRequest(Some(50), r.nextShardIterator)
+            GetRecordsRequest(Some(50), r.nextShardIterator, None)
               .getRecords(
                 streamsRef,
                 streamArn.awsRegion,

--- a/src/test/scala/kinesis/mock/api/GetShardIteratorTests.scala
+++ b/src/test/scala/kinesis/mock/api/GetShardIteratorTests.scala
@@ -52,7 +52,8 @@ class GetShardIteratorTests
           shard.shardId.shardId,
           ShardIteratorType.TRIM_HORIZON,
           None,
-          streamArn.streamName,
+          None,
+          Some(streamArn),
           None
         )
         res <- req.getShardIterator(
@@ -107,7 +108,8 @@ class GetShardIteratorTests
           shard.shardId.shardId,
           ShardIteratorType.LATEST,
           None,
-          streamArn.streamName,
+          None,
+          Some(streamArn),
           None
         )
         res <- req.getShardIterator(
@@ -166,7 +168,8 @@ class GetShardIteratorTests
           shard.shardId.shardId,
           ShardIteratorType.AT_TIMESTAMP,
           None,
-          streamArn.streamName,
+          None,
+          Some(streamArn),
           Some(startingInstant.plusSeconds(25L))
         )
         res <- req.getShardIterator(
@@ -225,7 +228,8 @@ class GetShardIteratorTests
           shard.shardId.shardId,
           ShardIteratorType.AT_SEQUENCE_NUMBER,
           Some(records(25).sequenceNumber),
-          streamArn.streamName,
+          None,
+          Some(streamArn),
           None
         )
         res <- req.getShardIterator(
@@ -282,7 +286,8 @@ class GetShardIteratorTests
           shard.shardId.shardId,
           ShardIteratorType.AT_SEQUENCE_NUMBER,
           Some(shard.sequenceNumberRange.startingSequenceNumber),
-          streamArn.streamName,
+          None,
+          Some(streamArn),
           None
         )
         res <- req.getShardIterator(
@@ -338,7 +343,8 @@ class GetShardIteratorTests
             shard.shardId.shardId,
             ShardIteratorType.AFTER_SEQUENCE_NUMBER,
             Some(records(25).sequenceNumber),
-            streamArn.streamName,
+            None,
+            Some(streamArn),
             None
           )
           res <- req.getShardIterator(
@@ -397,7 +403,8 @@ class GetShardIteratorTests
             shard.shardId.shardId,
             ShardIteratorType.AFTER_SEQUENCE_NUMBER,
             Some(shard.sequenceNumberRange.startingSequenceNumber),
-            streamArn.streamName,
+            None,
+            Some(streamArn),
             None
           )
           res <- req.getShardIterator(
@@ -432,7 +439,8 @@ class GetShardIteratorTests
           shard.shardId.shardId,
           ShardIteratorType.AT_TIMESTAMP,
           None,
-          streamArn.streamName,
+          None,
+          Some(streamArn),
           None
         )
         res <- req.getShardIterator(
@@ -459,7 +467,8 @@ class GetShardIteratorTests
             shard.shardId.shardId,
             ShardIteratorType.AT_TIMESTAMP,
             None,
-            streamArn.streamName,
+            None,
+            Some(streamArn),
             Some(Instant.now().plusSeconds(30))
           )
           res <- req.getShardIterator(
@@ -487,7 +496,8 @@ class GetShardIteratorTests
             shard.shardId.shardId,
             ShardIteratorType.AT_SEQUENCE_NUMBER,
             None,
-            streamArn.streamName,
+            None,
+            Some(streamArn),
             None
           )
           res <- req.getShardIterator(
@@ -515,7 +525,8 @@ class GetShardIteratorTests
             shard.shardId.shardId,
             ShardIteratorType.AT_SEQUENCE_NUMBER,
             None,
-            streamArn.streamName,
+            None,
+            Some(streamArn),
             None
           )
           res <- req.getShardIterator(

--- a/src/test/scala/kinesis/mock/api/IncreaseStreamRetentionPeriodTests.scala
+++ b/src/test/scala/kinesis/mock/api/IncreaseStreamRetentionPeriodTests.scala
@@ -25,7 +25,7 @@ class IncreaseStreamRetentionPeriodTests
 
       for {
         streamsRef <- Ref.of[IO, Streams](active)
-        req = IncreaseStreamRetentionPeriodRequest(48, streamArn.streamName)
+        req = IncreaseStreamRetentionPeriodRequest(48, None, Some(streamArn))
         res <- req.increaseStreamRetention(
           streamsRef,
           streamArn.awsRegion,
@@ -56,7 +56,7 @@ class IncreaseStreamRetentionPeriodTests
 
       for {
         streamsRef <- Ref.of[IO, Streams](withUpdatedRetention)
-        req = IncreaseStreamRetentionPeriodRequest(48, streamArn.streamName)
+        req = IncreaseStreamRetentionPeriodRequest(48, None, Some(streamArn))
         res <- req.increaseStreamRetention(
           streamsRef,
           streamArn.awsRegion,

--- a/src/test/scala/kinesis/mock/api/ListShardsTests.scala
+++ b/src/test/scala/kinesis/mock/api/ListShardsTests.scala
@@ -31,7 +31,8 @@ class ListShardsTests
           None,
           None,
           None,
-          Some(streamArn.streamName)
+          None,
+          Some(streamArn)
         )
         res <- req.listShards(
           streamsRef,
@@ -64,7 +65,8 @@ class ListShardsTests
           None,
           None,
           None,
-          Some(streamArn.streamName)
+          None,
+          Some(streamArn)
         )
         res <- req.listShards(
           streamsRef,
@@ -77,6 +79,7 @@ class ListShardsTests
               None,
               Some(50),
               result.nextToken,
+              None,
               None,
               None,
               None
@@ -127,7 +130,8 @@ class ListShardsTests
           None,
           None,
           None,
-          Some(streamArn.streamName)
+          None,
+          Some(streamArn)
         )
         res <- req.listShards(
           streamsRef,
@@ -178,7 +182,8 @@ class ListShardsTests
           None,
           Some(filter),
           None,
-          Some(streamArn.streamName)
+          None,
+          Some(streamArn)
         )
         res <- req.listShards(
           streamsRef,
@@ -232,7 +237,8 @@ class ListShardsTests
           None,
           Some(filter),
           None,
-          Some(streamArn.streamName)
+          None,
+          Some(streamArn)
         )
         res <- req.listShards(
           streamsRef,
@@ -288,7 +294,8 @@ class ListShardsTests
             None,
             Some(filter),
             None,
-            Some(streamArn.streamName)
+            None,
+            Some(streamArn)
           )
           res <- req.listShards(
             streamsRef,
@@ -330,7 +337,8 @@ class ListShardsTests
           None,
           Some(filter),
           None,
-          Some(streamArn.streamName)
+          None,
+          Some(streamArn)
         )
         res <- req.listShards(
           streamsRef,
@@ -405,7 +413,8 @@ class ListShardsTests
           None,
           Some(filter),
           None,
-          Some(streamArn.streamName)
+          None,
+          Some(streamArn)
         )
         res <- req.listShards(
           streamsRef,
@@ -481,7 +490,8 @@ class ListShardsTests
           None,
           Some(filter),
           None,
-          Some(streamArn.streamName)
+          None,
+          Some(streamArn)
         )
         res <- req.listShards(
           streamsRef,
@@ -519,7 +529,8 @@ class ListShardsTests
           None,
           Some(ShardFilter(None, None, ShardFilterType.AT_TIMESTAMP)),
           None,
-          Some(streamArn.streamName)
+          None,
+          Some(streamArn)
         )
         res <- req.listShards(
           streamsRef,
@@ -546,7 +557,8 @@ class ListShardsTests
           None,
           Some(ShardFilter(None, None, ShardFilterType.FROM_TIMESTAMP)),
           None,
-          Some(streamArn.streamName)
+          None,
+          Some(streamArn)
         )
         res <- req.listShards(
           streamsRef,
@@ -573,7 +585,8 @@ class ListShardsTests
           None,
           Some(ShardFilter(None, None, ShardFilterType.AFTER_SHARD_ID)),
           None,
-          Some(streamArn.streamName)
+          None,
+          Some(streamArn)
         )
         res <- req.listShards(
           streamsRef,

--- a/src/test/scala/kinesis/mock/api/ListTagsForStreamTests.scala
+++ b/src/test/scala/kinesis/mock/api/ListTagsForStreamTests.scala
@@ -28,7 +28,7 @@ class ListTagsForStreamTests
 
       for {
         streamsRef <- Ref.of[IO, Streams](withTags)
-        req = ListTagsForStreamRequest(None, None, streamArn.streamName)
+        req = ListTagsForStreamRequest(None, None, None, Some(streamArn))
         res <- req.listTagsForStream(
           streamsRef,
           streamArn.awsRegion,
@@ -65,7 +65,8 @@ class ListTagsForStreamTests
         req = ListTagsForStreamRequest(
           Some(exclusiveStartTagKey),
           None,
-          streamArn.streamName
+          None,
+          Some(streamArn)
         )
         res <- req.listTagsForStream(
           streamsRef,
@@ -100,7 +101,7 @@ class ListTagsForStreamTests
 
       for {
         streamsRef <- Ref.of[IO, Streams](withTags)
-        req = ListTagsForStreamRequest(None, Some(5), streamArn.streamName)
+        req = ListTagsForStreamRequest(None, Some(5), None, Some(streamArn))
         res <- req.listTagsForStream(
           streamsRef,
           streamArn.awsRegion,

--- a/src/test/scala/kinesis/mock/api/MergeShardsTests.scala
+++ b/src/test/scala/kinesis/mock/api/MergeShardsTests.scala
@@ -31,7 +31,8 @@ class MergeShardsTests
         req = MergeShardsRequest(
           adjacentShardToMerge.shardId.shardId,
           shardToMerge.shardId.shardId,
-          streamArn.streamName
+          None,
+          Some(streamArn)
         )
         res <- req.mergeShards(
           streamsRef,
@@ -70,7 +71,8 @@ class MergeShardsTests
         MergeShardsRequest(
           adjacentShardToMerge.shardId.shardId,
           shardToMerge.shardId.shardId,
-          streamArn.streamName
+          None,
+          Some(streamArn)
         )
 
       for {
@@ -101,7 +103,8 @@ class MergeShardsTests
         MergeShardsRequest(
           adjacentShardToMerge.shardId,
           shardToMerge.shardId.shardId,
-          streamArn.streamName
+          None,
+          Some(streamArn)
         )
 
       for {
@@ -133,7 +136,8 @@ class MergeShardsTests
         MergeShardsRequest(
           adjacentShardToMerge.shardId.shardId,
           shardToMerge.shardId,
-          streamArn.streamName
+          None,
+          Some(streamArn)
         )
 
       for {
@@ -163,7 +167,8 @@ class MergeShardsTests
         MergeShardsRequest(
           adjacentShardToMerge.shardId.shardId,
           shardToMerge.shardId.shardId,
-          streamArn.streamName
+          None,
+          Some(streamArn)
         )
 
       for {

--- a/src/test/scala/kinesis/mock/api/RemoveTagsFromStreamTests.scala
+++ b/src/test/scala/kinesis/mock/api/RemoveTagsFromStreamTests.scala
@@ -35,7 +35,7 @@ class RemoveTagsFromStreamTests
 
       for {
         streamsRef <- Ref.of[IO, Streams](withTags)
-        req = RemoveTagsFromStreamRequest(streamArn.streamName, removedTags)
+        req = RemoveTagsFromStreamRequest(None, Some(streamArn), removedTags)
         res <- req.removeTagsFromStream(
           streamsRef,
           streamArn.awsRegion,

--- a/src/test/scala/kinesis/mock/api/SplitShardTests.scala
+++ b/src/test/scala/kinesis/mock/api/SplitShardTests.scala
@@ -38,7 +38,8 @@ class SplitShardTests
         SplitShardRequest(
           newStartingHashKey,
           shardToSplit.shardId.shardId,
-          streamArn.streamName
+          None,
+          Some(streamArn)
         )
 
       for {
@@ -83,7 +84,8 @@ class SplitShardTests
         SplitShardRequest(
           newStartingHashKey,
           shardToSplit.shardId.shardId,
-          streamArn.streamName
+          None,
+          Some(streamArn)
         )
 
       for {
@@ -121,7 +123,8 @@ class SplitShardTests
         SplitShardRequest(
           "0",
           shardToSplit.shardId,
-          streamArn.streamName
+          None,
+          Some(streamArn)
         )
 
       for {
@@ -161,7 +164,8 @@ class SplitShardTests
           SplitShardRequest(
             newStartingHashKey,
             shardToSplit.shardId.shardId,
-            streamArn.streamName
+            None,
+            Some(streamArn)
           )
 
         for {

--- a/src/test/scala/kinesis/mock/api/StartStreamEncryptionTests.scala
+++ b/src/test/scala/kinesis/mock/api/StartStreamEncryptionTests.scala
@@ -29,7 +29,8 @@ class StartStreamEncryptionTests
         req = StartStreamEncryptionRequest(
           EncryptionType.KMS,
           keyId,
-          streamArn.streamName
+          None,
+          Some(streamArn)
         )
         res <- req.startStreamEncryption(
           streamsRef,
@@ -68,7 +69,8 @@ class StartStreamEncryptionTests
           req = StartStreamEncryptionRequest(
             EncryptionType.NONE,
             keyId,
-            streamArn.streamName
+            None,
+            Some(streamArn)
           )
           res <- req.startStreamEncryption(
             streamsRef,
@@ -96,7 +98,8 @@ class StartStreamEncryptionTests
         req = StartStreamEncryptionRequest(
           EncryptionType.KMS,
           keyId,
-          streamArn.streamName
+          None,
+          Some(streamArn)
         )
         res <- req.startStreamEncryption(
           streamsRef,

--- a/src/test/scala/kinesis/mock/api/StopStreamEncryptionTests.scala
+++ b/src/test/scala/kinesis/mock/api/StopStreamEncryptionTests.scala
@@ -29,7 +29,8 @@ class StopStreamEncryptionTests
         req = StopStreamEncryptionRequest(
           EncryptionType.KMS,
           keyId,
-          streamArn.streamName
+          None,
+          Some(streamArn)
         )
         res <- req.stopStreamEncryption(
           streamsRef,
@@ -68,7 +69,8 @@ class StopStreamEncryptionTests
           req = StopStreamEncryptionRequest(
             EncryptionType.NONE,
             keyId,
-            streamArn.streamName
+            None,
+            Some(streamArn)
           )
           res <- req.stopStreamEncryption(
             streamsRef,
@@ -96,7 +98,8 @@ class StopStreamEncryptionTests
         req = StopStreamEncryptionRequest(
           EncryptionType.KMS,
           keyId,
-          streamArn.streamName
+          None,
+          Some(streamArn)
         )
         res <- req.stopStreamEncryption(
           streamsRef,

--- a/src/test/scala/kinesis/mock/api/UpdateShardCountTests.scala
+++ b/src/test/scala/kinesis/mock/api/UpdateShardCountTests.scala
@@ -26,7 +26,8 @@ class UpdateShardCountTests
       val req =
         UpdateShardCountRequest(
           ScalingType.UNIFORM_SCALING,
-          streamArn.streamName,
+          None,
+          Some(streamArn),
           10
         )
 
@@ -79,7 +80,8 @@ class UpdateShardCountTests
       val req =
         UpdateShardCountRequest(
           ScalingType.UNIFORM_SCALING,
-          streamArn.streamName,
+          None,
+          Some(streamArn),
           5
         )
 
@@ -135,7 +137,8 @@ class UpdateShardCountTests
       val req =
         UpdateShardCountRequest(
           ScalingType.UNIFORM_SCALING,
-          streamArn.streamName,
+          None,
+          Some(streamArn),
           firstRoundShardCount
         )
       val finalShardCount = req.targetShardCount / 2
@@ -223,7 +226,8 @@ class UpdateShardCountTests
       val req =
         UpdateShardCountRequest(
           ScalingType.UNIFORM_SCALING,
-          streamArn.streamName,
+          None,
+          Some(streamArn),
           firstRoundShardCount
         )
       val finalShardCount = req.targetShardCount * 2
@@ -308,7 +312,8 @@ class UpdateShardCountTests
         val req =
           UpdateShardCountRequest(
             ScalingType.UNIFORM_SCALING,
-            streamArn.streamName,
+            None,
+            Some(streamArn),
             11
           )
 
@@ -339,7 +344,8 @@ class UpdateShardCountTests
         val req =
           UpdateShardCountRequest(
             ScalingType.UNIFORM_SCALING,
-            streamArn.streamName,
+            None,
+            Some(streamArn),
             4
           )
 
@@ -369,7 +375,8 @@ class UpdateShardCountTests
       val req =
         UpdateShardCountRequest(
           ScalingType.UNIFORM_SCALING,
-          streamArn.streamName,
+          None,
+          Some(streamArn),
           10
         )
 
@@ -394,7 +401,8 @@ class UpdateShardCountTests
       val req =
         UpdateShardCountRequest(
           ScalingType.UNIFORM_SCALING,
-          streamArn.streamName,
+          None,
+          Some(streamArn),
           10
         )
 

--- a/src/test/scala/kinesis/mock/cache/AddTagsToStreamTests.scala
+++ b/src/test/scala/kinesis/mock/cache/AddTagsToStreamTests.scala
@@ -36,7 +36,7 @@ class AddTagsToStreamTests
           .rethrow
         _ <- cache
           .addTagsToStream(
-            AddTagsToStreamRequest(streamName, tags),
+            AddTagsToStreamRequest(Some(streamName), None, tags),
             context,
             false,
             Some(awsRegion)
@@ -44,7 +44,12 @@ class AddTagsToStreamTests
           .rethrow
         res <- cache
           .listTagsForStream(
-            ListTagsForStreamRequest(None, None, streamName),
+            ListTagsForStreamRequest(
+              None,
+              None,
+              Some(streamName),
+              None
+            ),
             context,
             false,
             Some(awsRegion)

--- a/src/test/scala/kinesis/mock/cache/CreateStreamTests.scala
+++ b/src/test/scala/kinesis/mock/cache/CreateStreamTests.scala
@@ -36,7 +36,10 @@ class CreateStreamTests
             Some(awsRegion)
           )
           .rethrow
-        describeStreamSummaryReq = DescribeStreamSummaryRequest(streamName)
+        describeStreamSummaryReq = DescribeStreamSummaryRequest(
+          Some(streamName),
+          None
+        )
         checkStream1 <- cache.describeStreamSummary(
           describeStreamSummaryReq,
           context,

--- a/src/test/scala/kinesis/mock/cache/DecreaseStreamRetentionPeriodTests.scala
+++ b/src/test/scala/kinesis/mock/cache/DecreaseStreamRetentionPeriodTests.scala
@@ -39,7 +39,7 @@ class DecreaseStreamRetentionPeriodTests
         _ <- IO.sleep(cacheConfig.createStreamDuration.plus(400.millis))
         _ <- cache
           .increaseStreamRetention(
-            IncreaseStreamRetentionPeriodRequest(48, streamName),
+            IncreaseStreamRetentionPeriodRequest(48, Some(streamName), None),
             context,
             false,
             Some(awsRegion)
@@ -47,7 +47,7 @@ class DecreaseStreamRetentionPeriodTests
           .rethrow
         _ <- cache
           .decreaseStreamRetention(
-            DecreaseStreamRetentionPeriodRequest(24, streamName),
+            DecreaseStreamRetentionPeriodRequest(24, Some(streamName), None),
             context,
             false,
             Some(awsRegion)
@@ -55,7 +55,7 @@ class DecreaseStreamRetentionPeriodTests
           .rethrow
         res <- cache
           .describeStreamSummary(
-            DescribeStreamSummaryRequest(streamName),
+            DescribeStreamSummaryRequest(Some(streamName), None),
             context,
             false,
             Some(awsRegion)

--- a/src/test/scala/kinesis/mock/cache/DeleteStreamTests.scala
+++ b/src/test/scala/kinesis/mock/cache/DeleteStreamTests.scala
@@ -39,13 +39,16 @@ class DeleteStreamTests
         _ <- IO.sleep(cacheConfig.createStreamDuration.plus(400.millis))
         res <- cache
           .deleteStream(
-            DeleteStreamRequest(streamName, None),
+            DeleteStreamRequest(Some(streamName), None, None),
             context,
             false,
             Some(awsRegion)
           )
           .rethrow
-        describeStreamSummaryReq = DescribeStreamSummaryRequest(streamName)
+        describeStreamSummaryReq = DescribeStreamSummaryRequest(
+          Some(streamName),
+          None
+        )
         checkStream1 <- cache.describeStreamSummary(
           describeStreamSummaryReq,
           context,

--- a/src/test/scala/kinesis/mock/cache/DescribeStreamSummaryTests.scala
+++ b/src/test/scala/kinesis/mock/cache/DescribeStreamSummaryTests.scala
@@ -35,7 +35,7 @@ class DescribeStreamSummaryTests
           .rethrow
         res <- cache
           .describeStreamSummary(
-            DescribeStreamSummaryRequest(streamName),
+            DescribeStreamSummaryRequest(Some(streamName), None),
             context,
             false,
             Some(awsRegion)

--- a/src/test/scala/kinesis/mock/cache/DescribeStreamTests.scala
+++ b/src/test/scala/kinesis/mock/cache/DescribeStreamTests.scala
@@ -35,7 +35,7 @@ class DescribeStreamTests
           .rethrow
         res <- cache
           .describeStream(
-            DescribeStreamRequest(None, None, streamName),
+            DescribeStreamRequest(None, None, Some(streamName), None),
             context,
             false,
             Some(awsRegion)
@@ -49,7 +49,8 @@ class DescribeStreamTests
               None,
               None,
               None,
-              Some(streamName)
+              Some(streamName),
+              None
             ),
             context,
             false,

--- a/src/test/scala/kinesis/mock/cache/DisableEnhancedMonitoringTests.scala
+++ b/src/test/scala/kinesis/mock/cache/DisableEnhancedMonitoringTests.scala
@@ -37,7 +37,8 @@ class DisableEnhancedMonitoringTests
           .enableEnhancedMonitoring(
             EnableEnhancedMonitoringRequest(
               Vector(ShardLevelMetric.ALL),
-              streamName
+              Some(streamName),
+              None
             ),
             context,
             false,
@@ -48,7 +49,8 @@ class DisableEnhancedMonitoringTests
           .disableEnhancedMonitoring(
             DisableEnhancedMonitoringRequest(
               Vector(ShardLevelMetric.IncomingBytes),
-              streamName
+              Some(streamName),
+              None
             ),
             context,
             false,
@@ -57,7 +59,7 @@ class DisableEnhancedMonitoringTests
           .rethrow
         streamMonitoring <- cache
           .describeStreamSummary(
-            DescribeStreamSummaryRequest(streamName),
+            DescribeStreamSummaryRequest(Some(streamName), None),
             context,
             false,
             Some(awsRegion)

--- a/src/test/scala/kinesis/mock/cache/EnableEnhancedMonitoringTests.scala
+++ b/src/test/scala/kinesis/mock/cache/EnableEnhancedMonitoringTests.scala
@@ -37,7 +37,8 @@ class EnableEnhancedMonitoringTests
           .enableEnhancedMonitoring(
             EnableEnhancedMonitoringRequest(
               Vector(ShardLevelMetric.IncomingBytes),
-              streamName
+              Some(streamName),
+              None
             ),
             context,
             false,
@@ -46,7 +47,7 @@ class EnableEnhancedMonitoringTests
           .rethrow
         streamMonitoring <- cache
           .describeStreamSummary(
-            DescribeStreamSummaryRequest(streamName),
+            DescribeStreamSummaryRequest(Some(streamName), None),
             context,
             false,
             Some(awsRegion)

--- a/src/test/scala/kinesis/mock/cache/GetRecordsTests.scala
+++ b/src/test/scala/kinesis/mock/cache/GetRecordsTests.scala
@@ -50,7 +50,15 @@ class GetRecordsTests
         )
         shard <- cache
           .listShards(
-            ListShardsRequest(None, None, None, None, None, Some(streamName)),
+            ListShardsRequest(
+              None,
+              None,
+              None,
+              None,
+              None,
+              Some(streamName),
+              None
+            ),
             context,
             false,
             Some(awsRegion)
@@ -63,7 +71,8 @@ class GetRecordsTests
               shard.shardId,
               ShardIteratorType.TRIM_HORIZON,
               None,
-              streamName,
+              Some(streamName),
+              None,
               None
             ),
             context,
@@ -74,7 +83,7 @@ class GetRecordsTests
           .map(_.shardIterator)
         res <- cache
           .getRecords(
-            GetRecordsRequest(None, shardIterator),
+            GetRecordsRequest(None, shardIterator, None),
             context,
             false,
             Some(awsRegion)

--- a/src/test/scala/kinesis/mock/cache/GetShardIteratorTests.scala
+++ b/src/test/scala/kinesis/mock/cache/GetShardIteratorTests.scala
@@ -39,7 +39,15 @@ class GetShardIteratorTests
         _ <- IO.sleep(cacheConfig.createStreamDuration.plus(400.millis))
         shard <- cache
           .listShards(
-            ListShardsRequest(None, None, None, None, None, Some(streamName)),
+            ListShardsRequest(
+              None,
+              None,
+              None,
+              None,
+              None,
+              Some(streamName),
+              None
+            ),
             context,
             false,
             Some(awsRegion)
@@ -52,7 +60,8 @@ class GetShardIteratorTests
               shard.shardId,
               ShardIteratorType.TRIM_HORIZON,
               None,
-              streamName,
+              Some(streamName),
+              None,
               None
             ),
             context,

--- a/src/test/scala/kinesis/mock/cache/IncreaseStreamRetentionPeriodTests.scala
+++ b/src/test/scala/kinesis/mock/cache/IncreaseStreamRetentionPeriodTests.scala
@@ -39,7 +39,7 @@ class IncreaseStreamRetentionPeriodTests
         _ <- IO.sleep(cacheConfig.createStreamDuration.plus(400.millis))
         _ <- cache
           .increaseStreamRetention(
-            IncreaseStreamRetentionPeriodRequest(48, streamName),
+            IncreaseStreamRetentionPeriodRequest(48, Some(streamName), None),
             context,
             false,
             Some(awsRegion)
@@ -47,7 +47,7 @@ class IncreaseStreamRetentionPeriodTests
           .rethrow
         res <- cache
           .describeStreamSummary(
-            DescribeStreamSummaryRequest(streamName),
+            DescribeStreamSummaryRequest(Some(streamName), None),
             context,
             false,
             Some(awsRegion)

--- a/src/test/scala/kinesis/mock/cache/ListShardsTests.scala
+++ b/src/test/scala/kinesis/mock/cache/ListShardsTests.scala
@@ -35,7 +35,15 @@ class ListShardsTests
           .rethrow
         res <- cache
           .listShards(
-            ListShardsRequest(None, None, None, None, None, Some(streamName)),
+            ListShardsRequest(
+              None,
+              None,
+              None,
+              None,
+              None,
+              Some(streamName),
+              None
+            ),
             context,
             false,
             Some(awsRegion)

--- a/src/test/scala/kinesis/mock/cache/ListStreamConsumersTests.scala
+++ b/src/test/scala/kinesis/mock/cache/ListStreamConsumersTests.scala
@@ -41,7 +41,7 @@ class ListStreamConsumersTests
         _ <- IO.sleep(cacheConfig.createStreamDuration.plus(400.millis))
         streamArn <- cache
           .describeStreamSummary(
-            DescribeStreamSummaryRequest(streamName),
+            DescribeStreamSummaryRequest(Some(streamName), None),
             context,
             false,
             Some(awsRegion)

--- a/src/test/scala/kinesis/mock/cache/ListTagsForStreamTests.scala
+++ b/src/test/scala/kinesis/mock/cache/ListTagsForStreamTests.scala
@@ -36,7 +36,7 @@ class ListTagsForStreamTests
           .rethrow
         _ <- cache
           .addTagsToStream(
-            AddTagsToStreamRequest(streamName, tags),
+            AddTagsToStreamRequest(Some(streamName), None, tags),
             context,
             false,
             Some(awsRegion)
@@ -44,7 +44,7 @@ class ListTagsForStreamTests
           .rethrow
         res <- cache
           .listTagsForStream(
-            ListTagsForStreamRequest(None, None, streamName),
+            ListTagsForStreamRequest(None, None, Some(streamName), None),
             context,
             false,
             Some(awsRegion)

--- a/src/test/scala/kinesis/mock/cache/MergeShardsTests.scala
+++ b/src/test/scala/kinesis/mock/cache/MergeShardsTests.scala
@@ -44,14 +44,18 @@ class MergeShardsTests
             MergeShardsRequest(
               adjacentParentShardId,
               parentShardId,
-              streamName
+              Some(streamName),
+              None
             ),
             context,
             false,
             Some(awsRegion)
           )
           .rethrow
-        describeStreamSummaryReq = DescribeStreamSummaryRequest(streamName)
+        describeStreamSummaryReq = DescribeStreamSummaryRequest(
+          Some(streamName),
+          None
+        )
         checkStream1 <- cache
           .describeStreamSummary(
             describeStreamSummaryReq,
@@ -77,7 +81,8 @@ class MergeShardsTests
               None,
               None,
               None,
-              Some(streamName)
+              Some(streamName),
+              None
             ),
             context,
             false,

--- a/src/test/scala/kinesis/mock/cache/PersistenceTests.scala
+++ b/src/test/scala/kinesis/mock/cache/PersistenceTests.scala
@@ -65,7 +65,15 @@ class PersistenceTests
         newCache <- Cache.loadFromFile(cacheConfig)
         shard <- newCache
           .listShards(
-            ListShardsRequest(None, None, None, None, None, Some(streamName)),
+            ListShardsRequest(
+              None,
+              None,
+              None,
+              None,
+              None,
+              Some(streamName),
+              None
+            ),
             context,
             false,
             Some(awsRegion)
@@ -78,7 +86,8 @@ class PersistenceTests
               shard.shardId,
               ShardIteratorType.TRIM_HORIZON,
               None,
-              streamName,
+              Some(streamName),
+              None,
               None
             ),
             context,
@@ -89,7 +98,7 @@ class PersistenceTests
           .map(_.shardIterator)
         res <- newCache
           .getRecords(
-            GetRecordsRequest(None, shardIterator),
+            GetRecordsRequest(None, shardIterator, None),
             context,
             false,
             Some(awsRegion)

--- a/src/test/scala/kinesis/mock/cache/PutRecordTests.scala
+++ b/src/test/scala/kinesis/mock/cache/PutRecordTests.scala
@@ -51,7 +51,15 @@ class PutRecordTests
         )
         shard <- cache
           .listShards(
-            ListShardsRequest(None, None, None, None, None, Some(streamName)),
+            ListShardsRequest(
+              None,
+              None,
+              None,
+              None,
+              None,
+              Some(streamName),
+              None
+            ),
             context,
             false,
             Some(awsRegion)
@@ -64,7 +72,8 @@ class PutRecordTests
               shard.shardId,
               ShardIteratorType.TRIM_HORIZON,
               None,
-              streamName,
+              Some(streamName),
+              None,
               None
             ),
             context,
@@ -75,7 +84,7 @@ class PutRecordTests
           .map(_.shardIterator)
         res <- cache
           .getRecords(
-            GetRecordsRequest(None, shardIterator),
+            GetRecordsRequest(None, shardIterator, None),
             context,
             false,
             Some(awsRegion)

--- a/src/test/scala/kinesis/mock/cache/PutRecordsTests.scala
+++ b/src/test/scala/kinesis/mock/cache/PutRecordsTests.scala
@@ -52,7 +52,15 @@ class PutRecordsTests
         _ <- cache.putRecords(req, context, false, Some(awsRegion)).rethrow
         shard <- cache
           .listShards(
-            ListShardsRequest(None, None, None, None, None, Some(streamName)),
+            ListShardsRequest(
+              None,
+              None,
+              None,
+              None,
+              None,
+              Some(streamName),
+              None
+            ),
             context,
             false,
             Some(awsRegion)
@@ -65,7 +73,8 @@ class PutRecordsTests
               shard.shardId,
               ShardIteratorType.TRIM_HORIZON,
               None,
-              streamName,
+              Some(streamName),
+              None,
               None
             ),
             context,
@@ -76,7 +85,7 @@ class PutRecordsTests
           .map(_.shardIterator)
         res <- cache
           .getRecords(
-            GetRecordsRequest(None, shardIterator),
+            GetRecordsRequest(None, shardIterator, None),
             context,
             false,
             Some(awsRegion)

--- a/src/test/scala/kinesis/mock/cache/RemoveTagsFromStreamTests.scala
+++ b/src/test/scala/kinesis/mock/cache/RemoveTagsFromStreamTests.scala
@@ -36,21 +36,25 @@ class RemoveTagsFromStreamTests
           .rethrow
         _ <- cache
           .addTagsToStream(
-            AddTagsToStreamRequest(streamName, tags),
+            AddTagsToStreamRequest(Some(streamName), None, tags),
             context,
             false,
             Some(awsRegion)
           )
           .rethrow
         _ <- cache.removeTagsFromStream(
-          RemoveTagsFromStreamRequest(streamName, tags.tags.keys.toVector),
+          RemoveTagsFromStreamRequest(
+            Some(streamName),
+            None,
+            tags.tags.keys.toVector
+          ),
           context,
           false,
           Some(awsRegion)
         )
         res <- cache
           .listTagsForStream(
-            ListTagsForStreamRequest(None, None, streamName),
+            ListTagsForStreamRequest(None, None, Some(streamName), None),
             context,
             false,
             Some(awsRegion)

--- a/src/test/scala/kinesis/mock/cache/SplitShardTests.scala
+++ b/src/test/scala/kinesis/mock/cache/SplitShardTests.scala
@@ -43,7 +43,8 @@ class SplitShardTests
           None,
           None,
           None,
-          Some(streamName)
+          Some(streamName),
+          None
         )
         shardToSplit <- cache
           .listShards(listShardsReq, context, false, Some(awsRegion))
@@ -55,14 +56,18 @@ class SplitShardTests
             SplitShardRequest(
               newStartingHashKey.toString(),
               shardToSplit.shardId,
-              streamName
+              Some(streamName),
+              None
             ),
             context,
             false,
             Some(awsRegion)
           )
           .rethrow
-        describeStreamSummaryReq = DescribeStreamSummaryRequest(streamName)
+        describeStreamSummaryReq = DescribeStreamSummaryRequest(
+          Some(streamName),
+          None
+        )
         checkStream1 <- cache
           .describeStreamSummary(
             describeStreamSummaryReq,

--- a/src/test/scala/kinesis/mock/cache/StartStreamEncryptionTests.scala
+++ b/src/test/scala/kinesis/mock/cache/StartStreamEncryptionTests.scala
@@ -44,14 +44,15 @@ class StartStreamEncryptionTests
             StartStreamEncryptionRequest(
               EncryptionType.KMS,
               keyId,
-              streamName
+              Some(streamName),
+              None
             ),
             context,
             false,
             Some(awsRegion)
           )
           .rethrow
-        describeReq = DescribeStreamSummaryRequest(streamName)
+        describeReq = DescribeStreamSummaryRequest(Some(streamName), None)
         checkStream1 <- cache
           .describeStreamSummary(describeReq, context, false, Some(awsRegion))
           .rethrow

--- a/src/test/scala/kinesis/mock/cache/StopStreamEncryptionTests.scala
+++ b/src/test/scala/kinesis/mock/cache/StopStreamEncryptionTests.scala
@@ -44,7 +44,8 @@ class StopStreamEncryptionTests
             StartStreamEncryptionRequest(
               EncryptionType.KMS,
               keyId,
-              streamName
+              Some(streamName),
+              None
             ),
             context,
             false,
@@ -59,14 +60,15 @@ class StopStreamEncryptionTests
             StopStreamEncryptionRequest(
               EncryptionType.KMS,
               keyId,
-              streamName
+              Some(streamName),
+              None
             ),
             context,
             false,
             Some(awsRegion)
           )
           .rethrow
-        describeReq = DescribeStreamSummaryRequest(streamName)
+        describeReq = DescribeStreamSummaryRequest(Some(streamName), None)
         checkStream1 <- cache
           .describeStreamSummary(describeReq, context, false, Some(awsRegion))
           .rethrow

--- a/src/test/scala/kinesis/mock/cache/UpdateShardCountTests.scala
+++ b/src/test/scala/kinesis/mock/cache/UpdateShardCountTests.scala
@@ -41,7 +41,8 @@ class UpdateShardCountTests
           .updateShardCount(
             UpdateShardCountRequest(
               ScalingType.UNIFORM_SCALING,
-              streamName,
+              Some(streamName),
+              None,
               10
             ),
             context,
@@ -49,7 +50,10 @@ class UpdateShardCountTests
             Some(awsRegion)
           )
           .rethrow
-        describeStreamSummaryReq = DescribeStreamSummaryRequest(streamName)
+        describeStreamSummaryReq = DescribeStreamSummaryRequest(
+          Some(streamName),
+          None
+        )
         checkStream1 <- cache
           .describeStreamSummary(
             describeStreamSummaryReq,
@@ -69,7 +73,15 @@ class UpdateShardCountTests
           .rethrow
         checkShards <- cache
           .listShards(
-            ListShardsRequest(None, None, None, None, None, Some(streamName)),
+            ListShardsRequest(
+              None,
+              None,
+              None,
+              None,
+              None,
+              Some(streamName),
+              None
+            ),
             context,
             false,
             Some(awsRegion)

--- a/src/test/scala/kinesis/mock/cache/UpdateStreamModeTests.scala
+++ b/src/test/scala/kinesis/mock/cache/UpdateStreamModeTests.scala
@@ -50,7 +50,7 @@ class UpdateStreamModeTests
           .rethrow
         res1 <- cache
           .describeStreamSummary(
-            DescribeStreamSummaryRequest(streamName),
+            DescribeStreamSummaryRequest(Some(streamName), None),
             context,
             false,
             Some(awsRegion)
@@ -59,7 +59,7 @@ class UpdateStreamModeTests
         _ <- IO.sleep(cacheConfig.updateStreamModeDuration.plus(400.millis))
         res2 <- cache
           .describeStreamSummary(
-            DescribeStreamSummaryRequest(streamName),
+            DescribeStreamSummaryRequest(Some(streamName), None),
             context,
             false,
             Some(awsRegion)


### PR DESCRIPTION
## Changes Introduced

Prior to this PR, `GetRecords` would not allow consumption of closed shards, which meant that users who scaled their streams could not consume from them anymore. This is incorrect behavior. That restriction is removed.

This PR also adds `StreamARN` parameter support to several other API calls, as Kinesis has added the same:
- AddTagsToStream
- RemoveTagsFromStream
- DecreaseStreamRetentionPeriod
- IncreaseStreamRetentionPeriod
- DisableEnhancedMonitoring
- EnableEnhancedMonitoring
- GetRecords
- GetShardIterator
- ListShards
- ListTagsForStream
- MergeShards
- SplitShard
- StopStreamEncryption
- StartStreamEncryption
- UpdateShardCount

There were also several issues with how GetRecords, SplitShard, MergeSahrds and UpdateShardCount worked together that were fixed in this PR. 


## Applicable linked issues

N/A

## Checklist (check all that apply)

- [x] This change maintains backwards compatibility
- [x] I have introduced tests for all new features and changes
- [ ] I have added documentation covering all new features and changes
- [x] This pull-request is ready for review