### PR TITLE
EnhancedMonitoring and FailedRecordCount outputs should be nullable

### DIFF
--- a/src/fun/scala/kinesis/mock/DescribeStreamSummaryTests.scala
+++ b/src/fun/scala/kinesis/mock/DescribeStreamSummaryTests.scala
@@ -1,7 +1,5 @@
 package kinesis.mock
 
-import java.util.Collections
-
 import cats.syntax.all._
 import software.amazon.awssdk.services.kinesis.model._
 
@@ -14,12 +12,6 @@ class DescribeStreamSummaryTests extends AwsFunctionalTests {
         .builder()
         .consumerCount(0)
         .encryptionType(EncryptionType.NONE)
-        .enhancedMonitoring(
-          EnhancedMetrics
-            .builder()
-            .shardLevelMetricsWithStrings(Collections.emptyList[String]())
-            .build()
-        )
         .openShardCount(genStreamShardCount)
         .retentionPeriodHours(24)
         .streamARN(

--- a/src/fun/scala/kinesis/mock/DescribeStreamTests.scala
+++ b/src/fun/scala/kinesis/mock/DescribeStreamTests.scala
@@ -1,7 +1,5 @@
 package kinesis.mock
 
-import java.util.Collections
-
 import software.amazon.awssdk.services.kinesis.model._
 
 import kinesis.mock.syntax.javaFuture._
@@ -21,12 +19,6 @@ class DescribeStreamTests extends AwsFunctionalTests {
       expected = StreamDescription
         .builder()
         .encryptionType(EncryptionType.NONE)
-        .enhancedMonitoring(
-          EnhancedMetrics
-            .builder()
-            .shardLevelMetricsWithStrings(Collections.emptyList[String]())
-            .build()
-        )
         .hasMoreShards(false)
         .shards(res.streamDescription().shards())
         .retentionPeriodHours(24)

--- a/src/main/scala/kinesis/mock/api/DeleteStreamRequest.scala
+++ b/src/main/scala/kinesis/mock/api/DeleteStreamRequest.scala
@@ -51,7 +51,7 @@ final case class DeleteStreamRequest(
                   shards = SortedMap.empty,
                   streamStatus = StreamStatus.DELETING,
                   tags = Tags.empty,
-                  enhancedMonitoring = Vector.empty,
+                  enhancedMonitoring = None,
                   consumers = SortedMap.empty
                 )
               )

--- a/src/main/scala/kinesis/mock/api/DisableEnhancedMonitoringResponse.scala
+++ b/src/main/scala/kinesis/mock/api/DisableEnhancedMonitoringResponse.scala
@@ -7,8 +7,8 @@ import io.circe
 import kinesis.mock.models._
 
 final case class DisableEnhancedMonitoringResponse(
-    currentShardLevelMetrics: Vector[ShardLevelMetric],
-    desiredShardLevelMetrics: Vector[ShardLevelMetric],
+    currentShardLevelMetrics: Option[Vector[ShardLevelMetric]],
+    desiredShardLevelMetrics: Option[Vector[ShardLevelMetric]],
     streamName: StreamName,
     streamArn: StreamArn
 )
@@ -35,10 +35,10 @@ object DisableEnhancedMonitoringResponse {
     for {
       currentShardLevelMetrics <- x
         .downField("CurrentShardLevelMetrics")
-        .as[Vector[ShardLevelMetric]]
+        .as[Option[Vector[ShardLevelMetric]]]
       desiredShardLevelMetrics <- x
         .downField("DesiredShardLevelMetrics")
-        .as[Vector[ShardLevelMetric]]
+        .as[Option[Vector[ShardLevelMetric]]]
       streamName <- x.downField("StreamName").as[StreamName]
       streamArn <- x.downField("StreamARN").as[StreamArn]
     } yield DisableEnhancedMonitoringResponse(

--- a/src/main/scala/kinesis/mock/api/EnableEnhancedMonitoringResponse.scala
+++ b/src/main/scala/kinesis/mock/api/EnableEnhancedMonitoringResponse.scala
@@ -7,8 +7,8 @@ import io.circe
 import kinesis.mock.models._
 
 final case class EnableEnhancedMonitoringResponse(
-    currentShardLevelMetrics: Vector[ShardLevelMetric],
-    desiredShardLevelMetrics: Vector[ShardLevelMetric],
+    currentShardLevelMetrics: Option[Vector[ShardLevelMetric]],
+    desiredShardLevelMetrics: Option[Vector[ShardLevelMetric]],
     streamName: StreamName,
     streamArn: StreamArn
 )
@@ -35,10 +35,10 @@ object EnableEnhancedMonitoringResponse {
     for {
       currentShardLevelMetrics <- x
         .downField("CurrentShardLevelMetrics")
-        .as[Vector[ShardLevelMetric]]
+        .as[Option[Vector[ShardLevelMetric]]]
       desiredShardLevelMetrics <- x
         .downField("DesiredShardLevelMetrics")
-        .as[Vector[ShardLevelMetric]]
+        .as[Option[Vector[ShardLevelMetric]]]
       streamName <- x.downField("StreamName").as[StreamName]
       streamArn <- x.downField("StreamARN").as[StreamArn]
     } yield EnableEnhancedMonitoringResponse(

--- a/src/main/scala/kinesis/mock/api/PutRecordsRequest.scala
+++ b/src/main/scala/kinesis/mock/api/PutRecordsRequest.scala
@@ -117,7 +117,7 @@ final case class PutRecordsRequest(
             ),
             PutRecordsResponse(
               stream.encryptionType,
-              0,
+              None,
               asRecords.map { case (_, _, _, entry) =>
                 entry
               }

--- a/src/main/scala/kinesis/mock/api/PutRecordsResponse.scala
+++ b/src/main/scala/kinesis/mock/api/PutRecordsResponse.scala
@@ -8,7 +8,7 @@ import kinesis.mock.models.EncryptionType
 
 final case class PutRecordsResponse(
     encryptionType: EncryptionType,
-    failedRecordCount: Int,
+    failedRecordCount: Option[Int],
     records: Vector[PutRecordsResultEntry]
 )
 
@@ -26,7 +26,7 @@ object PutRecordsResponse {
     x =>
       for {
         encryptionType <- x.downField("EncryptionType").as[EncryptionType]
-        failedRecordCount <- x.downField("FailedRecordCount").as[Int]
+        failedRecordCount <- x.downField("FailedRecordCount").as[Option[Int]]
         records <- x.downField("Records").as[Vector[PutRecordsResultEntry]]
       } yield PutRecordsResponse(encryptionType, failedRecordCount, records)
 

--- a/src/main/scala/kinesis/mock/models/StreamData.scala
+++ b/src/main/scala/kinesis/mock/models/StreamData.scala
@@ -15,7 +15,7 @@ import kinesis.mock.instances.circe._
 final case class StreamData(
     consumers: SortedMap[ConsumerName, Consumer],
     encryptionType: EncryptionType,
-    enhancedMonitoring: Vector[ShardLevelMetrics],
+    enhancedMonitoring: Option[Vector[ShardLevelMetrics]],
     keyId: Option[String],
     retentionPeriod: FiniteDuration,
     shards: SortedMap[Shard, Vector[KinesisRecord]],
@@ -81,7 +81,7 @@ object StreamData {
       encryptionType <- x.downField("encryptionType").as[EncryptionType]
       enhancedMonitoring <- x
         .downField("enhancedMonitoring")
-        .as[Vector[ShardLevelMetrics]]
+        .as[Option[Vector[ShardLevelMetrics]]]
       keyId <- x.downField("keyId").as[Option[String]]
       retentionPeriod <- x.downField("retentionPeriod").as[FiniteDuration]
       shards <- x
@@ -144,7 +144,7 @@ object StreamData {
     StreamData(
       SortedMap.empty,
       EncryptionType.NONE,
-      Vector(ShardLevelMetrics(Vector.empty)),
+      None,
       None,
       minRetentionPeriod,
       shards,

--- a/src/main/scala/kinesis/mock/models/StreamDescription.scala
+++ b/src/main/scala/kinesis/mock/models/StreamDescription.scala
@@ -11,7 +11,7 @@ import kinesis.mock.instances.circe._
 
 final case class StreamDescription(
     encryptionType: Option[EncryptionType],
-    enhancedMonitoring: Vector[ShardLevelMetrics],
+    enhancedMonitoring: Option[Vector[ShardLevelMetrics]],
     hasMoreShards: Boolean,
     keyId: Option[String],
     retentionPeriodHours: Int,
@@ -100,7 +100,7 @@ object StreamDescription {
         .as[Option[EncryptionType]]
       enhancedMonitoring <- x
         .downField("EnhancedMonitoring")
-        .as[Vector[ShardLevelMetrics]]
+        .as[Option[Vector[ShardLevelMetrics]]]
       hasMoreShards <- x.downField("HasMoreShards").as[Boolean]
       keyId <- x.downField("KeyId").as[Option[String]]
       retentionPeriodHours <- x.downField("RetentionPeriodHours").as[Int]

--- a/src/main/scala/kinesis/mock/models/StreamDescriptionSummary.scala
+++ b/src/main/scala/kinesis/mock/models/StreamDescriptionSummary.scala
@@ -11,7 +11,7 @@ import kinesis.mock.instances.circe._
 final case class StreamDescriptionSummary(
     consumerCount: Option[Int],
     encryptionType: Option[EncryptionType],
-    enhancedMonitoring: Vector[ShardLevelMetrics],
+    enhancedMonitoring: Option[Vector[ShardLevelMetrics]],
     keyId: Option[String],
     openShardCount: Int,
     retentionPeriodHours: Int,
@@ -76,7 +76,7 @@ object StreamDescriptionSummary {
       encryptionType <- x.downField("EncryptionType").as[Option[EncryptionType]]
       enhancedMonitoring <- x
         .downField("EnhancedMonitoring")
-        .as[Vector[ShardLevelMetrics]]
+        .as[Option[Vector[ShardLevelMetrics]]]
       keyId <- x.downField("KeyId").as[Option[String]]
       openShardCount <- x.downField("OpenShardCount").as[Int]
       retentionPeriodHours <- x.downField("RetentionPeriodHours").as[Int]

--- a/src/main/scala/kinesis/mock/models/Streams.scala
+++ b/src/main/scala/kinesis/mock/models/Streams.scala
@@ -42,7 +42,7 @@ final case class Streams(streams: SortedMap[StreamArn, StreamData]) {
             shards = SortedMap.empty,
             streamStatus = StreamStatus.DELETING,
             tags = Tags.empty,
-            enhancedMonitoring = Vector.empty,
+            enhancedMonitoring = None,
             consumers = SortedMap.empty
           )
         )

--- a/src/test/scala/kinesis/mock/api/DisableEnhancedMonitoringTests.scala
+++ b/src/test/scala/kinesis/mock/api/DisableEnhancedMonitoringTests.scala
@@ -21,16 +21,18 @@ class DisableEnhancedMonitoringTests
 
       val updated = streams.findAndUpdateStream(streamArn)(stream =>
         stream.copy(enhancedMonitoring =
-          Vector(
-            ShardLevelMetrics(
-              Vector(
-                ShardLevelMetric.IncomingBytes,
-                ShardLevelMetric.IncomingRecords,
-                ShardLevelMetric.OutgoingBytes,
-                ShardLevelMetric.OutgoingRecords,
-                ShardLevelMetric.WriteProvisionedThroughputExceeded,
-                ShardLevelMetric.ReadProvisionedThroughputExceeded,
-                ShardLevelMetric.IteratorAgeMilliseconds
+          Some(
+            Vector(
+              ShardLevelMetrics(
+                Vector(
+                  ShardLevelMetric.IncomingBytes,
+                  ShardLevelMetric.IncomingRecords,
+                  ShardLevelMetric.OutgoingBytes,
+                  ShardLevelMetric.OutgoingRecords,
+                  ShardLevelMetric.WriteProvisionedThroughputExceeded,
+                  ShardLevelMetric.ReadProvisionedThroughputExceeded,
+                  ShardLevelMetric.IteratorAgeMilliseconds
+                )
               )
             )
           )
@@ -52,7 +54,7 @@ class DisableEnhancedMonitoringTests
         s <- streamsRef.get
         updatedMetrics = s.streams
           .get(streamArn)
-          .map(_.enhancedMonitoring.flatMap(_.shardLevelMetrics))
+          .map(_.enhancedMonitoring.map(_.flatMap(_.shardLevelMetrics)))
 
       } yield assert(
         res.isRight && res.exists { case response =>

--- a/src/test/scala/kinesis/mock/api/EnableEnhancedMonitoringTests.scala
+++ b/src/test/scala/kinesis/mock/api/EnableEnhancedMonitoringTests.scala
@@ -34,7 +34,7 @@ class EnableEnhancedMonitoringTests
         s <- streamsRef.get
         updatedMetrics = s.streams
           .get(streamArn)
-          .map(_.enhancedMonitoring.flatMap(_.shardLevelMetrics))
+          .map(_.enhancedMonitoring.map(_.flatMap(_.shardLevelMetrics)))
 
       } yield assert(
         res.isRight && res.exists { case response =>

--- a/src/test/scala/kinesis/mock/cache/DescribeStreamSummaryTests.scala
+++ b/src/test/scala/kinesis/mock/cache/DescribeStreamSummaryTests.scala
@@ -44,7 +44,7 @@ class DescribeStreamSummaryTests
         expected = StreamDescriptionSummary(
           Some(0),
           Some(EncryptionType.NONE),
-          Vector(ShardLevelMetrics(Vector.empty)),
+          None,
           None,
           1,
           24,

--- a/src/test/scala/kinesis/mock/cache/DescribeStreamTests.scala
+++ b/src/test/scala/kinesis/mock/cache/DescribeStreamTests.scala
@@ -60,7 +60,7 @@ class DescribeStreamTests
           .map(x => x.shards)
         expected = StreamDescription(
           Some(EncryptionType.NONE),
-          Vector(ShardLevelMetrics(Vector.empty)),
+          None,
           false,
           None,
           24,

--- a/src/test/scala/kinesis/mock/cache/DisableEnhancedMonitoringTests.scala
+++ b/src/test/scala/kinesis/mock/cache/DisableEnhancedMonitoringTests.scala
@@ -67,7 +67,7 @@ class DisableEnhancedMonitoringTests
           .rethrow
           .map(
             _.streamDescriptionSummary.enhancedMonitoring
-              .flatMap(_.shardLevelMetrics)
+              .map(_.flatMap(_.shardLevelMetrics))
           )
       } yield assert(
         res.desiredShardLevelMetrics == streamMonitoring && !res.desiredShardLevelMetrics

--- a/src/test/scala/kinesis/mock/cache/DisableEnhancedMonitoringTests.scala
+++ b/src/test/scala/kinesis/mock/cache/DisableEnhancedMonitoringTests.scala
@@ -71,7 +71,7 @@ class DisableEnhancedMonitoringTests
           )
       } yield assert(
         res.desiredShardLevelMetrics == streamMonitoring && !res.desiredShardLevelMetrics
-          .contains(ShardLevelMetric.IncomingBytes)
+          .exists(_.contains(ShardLevelMetric.IncomingBytes))
       )
   })
 }

--- a/src/test/scala/kinesis/mock/cache/EnableEnhancedMonitoringTests.scala
+++ b/src/test/scala/kinesis/mock/cache/EnableEnhancedMonitoringTests.scala
@@ -59,7 +59,7 @@ class EnableEnhancedMonitoringTests
           )
       } yield assert(
         res.desiredShardLevelMetrics == streamMonitoring && res.desiredShardLevelMetrics
-          .contains(ShardLevelMetric.IncomingBytes)
+          .exists(_.contains(ShardLevelMetric.IncomingBytes))
       )
   })
 }

--- a/src/test/scala/kinesis/mock/cache/EnableEnhancedMonitoringTests.scala
+++ b/src/test/scala/kinesis/mock/cache/EnableEnhancedMonitoringTests.scala
@@ -55,7 +55,7 @@ class EnableEnhancedMonitoringTests
           .rethrow
           .map(
             _.streamDescriptionSummary.enhancedMonitoring
-              .flatMap(_.shardLevelMetrics)
+              .map(_.flatMap(_.shardLevelMetrics))
           )
       } yield assert(
         res.desiredShardLevelMetrics == streamMonitoring && res.desiredShardLevelMetrics

--- a/src/test/scala/kinesis/mock/instances/arbitrary.scala
+++ b/src/test/scala/kinesis/mock/instances/arbitrary.scala
@@ -367,14 +367,16 @@ object arbitrary {
   implicit val streamDescriptionArb: Arbitrary[StreamDescription] = Arbitrary(
     for {
       encryptionType <- Gen.option(Arbitrary.arbitrary[EncryptionType])
-      enhancedMonitoring <- Gen
-        .choose(0, 1)
-        .flatMap(size =>
-          Gen.containerOfN[Vector, ShardLevelMetrics](
-            size,
-            shardLevelMetricsArbitrary.arbitrary
+      enhancedMonitoring <- Gen.option(
+        Gen
+          .choose(1, 2)
+          .flatMap(size =>
+            Gen.containerOfN[Vector, ShardLevelMetrics](
+              size,
+              shardLevelMetricsArbitrary.arbitrary
+            )
           )
-        )
+      )
       hasMoreShards <- Arbitrary.arbitrary[Boolean]
       keyId <- Gen.option(keyIdGen)
       retentionPeriodHours <- retentionPeriodHoursGen
@@ -444,14 +446,16 @@ object arbitrary {
     for {
       consumerCount <- Gen.option(Gen.choose(1, 20))
       encryptionType <- Gen.option(Arbitrary.arbitrary[EncryptionType])
-      enhancedMonitoring <- Gen
-        .choose(0, 1)
-        .flatMap(size =>
-          Gen.containerOfN[Vector, ShardLevelMetrics](
-            size,
-            shardLevelMetricsArbitrary.arbitrary
+      enhancedMonitoring <- Gen.option(
+        Gen
+          .choose(1, 2)
+          .flatMap(size =>
+            Gen.containerOfN[Vector, ShardLevelMetrics](
+              size,
+              shardLevelMetricsArbitrary.arbitrary
+            )
           )
-        )
+      )
       keyId <- Gen.option(keyIdGen)
       openShardCount <- Gen.choose(1, 50)
       retentionPeriodHours <- retentionPeriodHoursGen
@@ -501,11 +505,15 @@ object arbitrary {
   implicit val disableEnhancedMonitoringResponseArb
       : Arbitrary[DisableEnhancedMonitoringResponse] = Arbitrary(
     for {
-      currentShardLevelMetrics <- shardLevelMetricsArbitrary.arbitrary.map(
-        _.shardLevelMetrics
+      currentShardLevelMetrics <- Gen.option(
+        shardLevelMetricsArbitrary.arbitrary.map(
+          _.shardLevelMetrics
+        )
       )
-      desiredShardLevelMetrics <- shardLevelMetricsArbitrary.arbitrary.map(
-        _.shardLevelMetrics
+      desiredShardLevelMetrics <- Gen.option(
+        shardLevelMetricsArbitrary.arbitrary.map(
+          _.shardLevelMetrics
+        )
       )
       streamArn <- streamArnGen
     } yield DisableEnhancedMonitoringResponse(
@@ -533,11 +541,13 @@ object arbitrary {
   implicit val enableEnhancedMonitoringResponseArb
       : Arbitrary[EnableEnhancedMonitoringResponse] = Arbitrary(
     for {
-      currentShardLevelMetrics <- shardLevelMetricsArbitrary.arbitrary.map(
-        _.shardLevelMetrics
+      currentShardLevelMetrics <- Gen.option(
+        shardLevelMetricsArbitrary.arbitrary.map(
+          _.shardLevelMetrics
+        )
       )
-      desiredShardLevelMetrics <- shardLevelMetricsArbitrary.arbitrary.map(
-        _.shardLevelMetrics
+      desiredShardLevelMetrics <- Gen.option(
+        shardLevelMetricsArbitrary.arbitrary.map(_.shardLevelMetrics)
       )
       streamArn <- streamArnGen
     } yield EnableEnhancedMonitoringResponse(
@@ -986,14 +996,16 @@ object arbitrary {
         )
         .map(x => SortedMap.from(x))
       encryptionType <- Arbitrary.arbitrary[EncryptionType]
-      enhancedMonitoring <- Gen
-        .choose(0, 1)
-        .flatMap(size =>
-          Gen.containerOfN[Vector, ShardLevelMetrics](
-            size,
-            shardLevelMetricsArbitrary.arbitrary
+      enhancedMonitoring <- Gen.option(
+        Gen
+          .choose(1, 2)
+          .flatMap(size =>
+            Gen.containerOfN[Vector, ShardLevelMetrics](
+              size,
+              shardLevelMetricsArbitrary.arbitrary
+            )
           )
-        )
+      )
       keyId <- Gen.option(keyIdGen)
       retentionPeriod <- retentionPeriodHoursGen.map(_.hours)
       shardsSize <- Gen.choose(0, 50)

--- a/src/test/scala/kinesis/mock/instances/arbitrary.scala
+++ b/src/test/scala/kinesis/mock/instances/arbitrary.scala
@@ -889,8 +889,8 @@ object arbitrary {
   implicit val putRecordsResponseArb: Arbitrary[PutRecordsResponse] = Arbitrary(
     for {
       encryptionType <- Arbitrary.arbitrary[EncryptionType]
-      failedRecordCount <- Gen.choose(0, 500)
-      recordsSize <- Gen.choose(failedRecordCount, 500)
+      failedRecordCount <- Gen.option(Gen.choose(1, 500))
+      recordsSize <- Gen.choose(failedRecordCount.getOrElse(1), 500)
       records <- Gen.containerOfN[Vector, PutRecordsResultEntry](
         recordsSize,
         putRecordsResultEntry.arbitrary


### PR DESCRIPTION
## Changes Introduced

Currently, the default values for EnhancedMonitoring in the stream data is an empty list. FailedRecordCount has a default of 0. These should actually be a null value, as the API requires this list to be 1 or greater (and enhanced monitoring is optional in general). FailedRecordCount must also be 1 or greater, and is also optional in general.

## Applicable linked issues

## Checklist (check all that apply)

- [x] This change maintains backwards compatibility
- [x] I have introduced tests for all new features and changes
- [ ] I have added documentation covering all new features and changes
- [x] This pull-request is ready for review