### PR TITLE
BUG: Don't fail ListShards if both StreamName and StreamARN are provided

### DIFF
--- a/src/main/scala/kinesis/mock/api/ListShardsRequest.scala
+++ b/src/main/scala/kinesis/mock/api/ListShardsRequest.scala
@@ -71,11 +71,11 @@ final case class ListShardsRequest(
               ListShardsResponse(nextToken, shards.map(ShardSummary.fromShard))
             })
           }
-      case (_, None, _, _, Some(sName), None) =>
+      case (_, None, _, _, _, Some(sArn)) =>
+        getList(sArn, sArn.streamName, streams)
+      case (_, None, _, _, Some(sName), _) =>
         val streamArn = StreamArn(awsRegion, sName, awsAccountId)
         getList(streamArn, sName, streams)
-      case (_, None, _, _, None, Some(sArn)) =>
-        getList(sArn, sArn.streamName, streams)
       case (_, None, _, _, None, None) =>
         InvalidArgumentException(
           "StreamName or StreamARN is required if NextToken is not provided"


### PR DESCRIPTION
## Changes Introduced

ListShards could fail if both StreamName and StreamARN were provided. The KPL does this, which was causing issues in creating its shard map.

## Applicable linked issues

## Checklist (check all that apply)

- [X] This change maintains backwards compatibility
- [X] I have introduced tests for all new features and changes
- [ ] I have added documentation covering all new features and changes
- [X] This pull-request is ready for review