### PR TITLE
Include server.json and LICENSE in NPM package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,6 +261,14 @@ jobs:
           asset_name: main.js.map
           asset_content_type: application/json
 
+      - name: Upload server.json
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: ./kinesis-mock/src/main/resources/server.json
+          asset_name: server.json
+          asset_content_type: application/json
+
   publishNPM:
     name: Publish To NPM
     needs: [build]

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ You can also leverage the following executable options in the release assets:
 | ---- | ----------- | --------- |
 | main.js | Executable NodeJS file that can be run in any NodeJS enabled environment | `node ./main.js` |
 | main.js.map | Source mappings for main.js | |
+| server.json | self-signed certificate for TLS. | |
 
 # Service Configuration
 
@@ -46,6 +47,10 @@ these ports to a local one).
 | INITIALIZE_STREAMS | String | | A comma-delimited string of stream names, its optional corresponding shard count and an optional region to initialize during startup. If the shard count is not provided, the default shard count of 4 is used. If the region is not provided, the default region is used. For example: "my-first-stream:1,my-other-stream::us-west-2,my-last-stream:1" |
 | KINESIS_MOCK_TLS_PORT | Int | 4567 | Https Only                                                                                                                                                                                                                                                                                                                                              |
 | KINESIS_MOCK_PLAIN_PORT | Int | 4568 | Http Only                                                                                                                                                                                                                                                                                                                                               |
+| KINESIS_MOCK_KEYSTORE_PASSWORD | Int | <redacted> | Password for the JKS KeyStore (only for JVM, not JS)
+| KINESIS_MOCK_KEYMANAGER_PASSWORD | Int | <redacted> | Password for the JKS KeyManager (only for JVM, not JS)
+| KINESIS_MOCK_CERT_PASSWORD | Int | <redacted> | Password used for self-signed certificate (only for JS, not JVM)
+| KINESIS_MOCK_CERT_PATH | Int | server.json | Path to certificate file (only for JS, not JVM)
 | CREATE_STREAM_DURATION | Duration | 500ms |                                                                                                                                                                                                                                                                                                                                                         |
 | DELETE_STREAM_DURATION | Duration | 500ms |                                                                                                                                                                                                                                                                                                                                                         |
 | REGISTER_STREAM_CONSUMER_DURATION | Duration | 500ms |                                                                                                                                                                                                                                                                                                                                                         |

--- a/README.md
+++ b/README.md
@@ -22,12 +22,27 @@ A mock for the [Kinesis](https://docs.aws.amazon.com/kinesis/latest/APIReference
 
 # Starting the service
 
+There are a few ways to start kinesis-mock.
+
+## Docker
+
 It is available as a docker image in the GitHub Container Registry:
 
 ```shell
 docker pull ghcr.io/etspaceman/kinesis-mock:0.4.1
 docker run -p 4567:4567 -p 4568:4568 ghcr.io/etspaceman/kinesis-mock:0.4.1
 ```
+
+## NPM
+
+It is available on [NPM](https://www.npmjs.com/package/kinesis-local) as an executable service.
+
+```shell
+npm i kinesis-local
+npx kinesis-local
+```
+
+## Manual
 
 You can also leverage the following executable options in the release assets:
 

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ You can also leverage the following executable options in the release assets:
 
 | File | Description | Launching |
 | ---- | ----------- | --------- |
-| main.js | Executable NodeJS file that can be run in any NodeJS enabled environment | `node ./main.js` |
-| main.js.map | Source mappings for main.js | |
-| server.json | self-signed certificate for TLS. | |
+| `main.js` | Executable NodeJS file that can be run in any NodeJS enabled environment | `node ./main.js` |
+| `main.js.map` | Source mappings for main.js | |
+| `server.json` | self-signed certificate for TLS. Should be included in the same area as `main.js` | |
 
 # Service Configuration
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,6 @@
 FROM node:18
 
 ARG DOCKER_SERVICE_FILE
-ENV KINESIS_MOCK_CERT_PATH="server.json"
 COPY ${DOCKER_SERVICE_FILE} ./main.js
 COPY ${DOCKER_SERVICE_FILE}.map ./main.js.map
 COPY kinesis-mock/src/main/resources/server.json ./server.json

--- a/kinesis-mock/src/main/scala/kinesis/mock/KinesisMockServiceConfig.scala
+++ b/kinesis-mock/src/main/scala/kinesis/mock/KinesisMockServiceConfig.scala
@@ -44,7 +44,7 @@ object KinesisMockServiceConfig {
       "password"
     )
     certPath <- env("KINESIS_MOCK_CERT_PATH").default(
-      "kinesis-mock/src/main/resources/server.json"
+      "server.json"
     )
   } yield KinesisMockServiceConfig(
     tlsPort,

--- a/project/KinesisMockPlugin.scala
+++ b/project/KinesisMockPlugin.scala
@@ -302,6 +302,16 @@ object KinesisMockPlugin extends AutoPlugin {
                 "asset_name" -> "main.js.map",
                 "asset_content_type" -> "application/json"
               )
+            ),
+            WorkflowStep.Use(
+              UseRef.Public("actions", "upload-release-asset", "v1"),
+              name = Some("Upload server.json"),
+              params = Map(
+                "upload_url" -> "${{ steps.get_release.outputs.upload_url }}",
+                "asset_path" -> "./kinesis-mock/src/main/resources/server.json",
+                "asset_name" -> "server.json",
+                "asset_content_type" -> "application/json"
+              )
             )
           ),
         scalas = Nil,
@@ -415,6 +425,13 @@ object KinesisMockPlugin extends AutoPlugin {
 }
 
 object KinesisMockPluginKeys {
+  def void(a: Any*): Unit = (a, ())._2
+
+  lazy val npmExtraFiles: SettingKey[Seq[File]] =
+    settingKey[Seq[File]]("Extra files to copy to the NPM install directory")
+  lazy val npmCopyExtraFiles =
+    taskKey[Unit]("Copy extra files to the NPM install directory")
+
   val Scala213 = "2.13.11"
 
   val testDependencies = Def.setting(


### PR DESCRIPTION
## Changes Introduced

server.json was not included in the published NPM package. This adds that file, as well as the LICENSE file. 

## Applicable linked issues

https://github.com/localstack/localstack/issues/8680

## Checklist (check all that apply)

- [X] This change maintains backwards compatibility
- [ ] I have introduced tests for all new features and changes
- [X] I have added documentation covering all new features and changes
- [X] This pull-request is ready for review