### PR TITLE
Enable Http2 Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,9 @@ jobs:
 
       - name: Integration Tests
         if: matrix.java == 'temurin@17' && matrix.os == 'ubuntu-latest' && startsWith(matrix.project, 'root-js')
+        env:
+          CBOR_ENABLED: ${{ matrix.cbor_enabled }}
+          SERVICE_PORT: ${{ matrix.service_port }}
         uses: nick-fields/retry@v2
         with:
           timeout_minutes: 15

--- a/README.md
+++ b/README.md
@@ -327,5 +327,4 @@ object MyApp {
 ```
 
 # Known issues
-- Does not currently support Http2 requests (https://github.com/http4s/http4s/issues/4707)
 - Does not currently support SubscribeToShard due to lack of push-promise support (https://github.com/http4s/http4s/issues/4624)

--- a/kinesis-mock/src/main/scala/kinesis/mock/KinesisMockService.scala
+++ b/kinesis-mock/src/main/scala/kinesis/mock/KinesisMockService.scala
@@ -88,12 +88,14 @@ object KinesisMockService extends IOApp {
         .withHost(host)
         .withTLS(tlsContext)
         .withHttpApp(app)
+        .withHttp2
         .build
       plainServer = EmberServerBuilder
         .default[IO]
         .withPort(serviceConfig.plainPort)
         .withHost(host)
         .withHttpApp(app)
+        .withHttp2
         .build
       _ <- logger.info(
         s"Starting Kinesis TLS Mock Service on port ${serviceConfig.tlsPort}"

--- a/kinesis-mock/src/main/scala/kinesis/mock/Utils.scala
+++ b/kinesis-mock/src/main/scala/kinesis/mock/Utils.scala
@@ -10,5 +10,7 @@ object Utils {
   def randomUUIDString = UUIDGen.randomString[SyncIO].unsafeRunSync()
   def md5(bytes: Array[Byte]): Array[Byte] = MD5.compute(bytes)
   def now =
-    SyncIO.realTime.map(d => Instant.EPOCH.plusNanos(d.toNanos)).unsafeRunSync()
+    SyncIO.monotonic
+      .map(d => Instant.EPOCH.plusNanos(d.toNanos))
+      .unsafeRunSync()
 }

--- a/kinesis-mock/src/main/scala/kinesis/mock/Utils.scala
+++ b/kinesis-mock/src/main/scala/kinesis/mock/Utils.scala
@@ -10,7 +10,5 @@ object Utils {
   def randomUUIDString = UUIDGen.randomString[SyncIO].unsafeRunSync()
   def md5(bytes: Array[Byte]): Array[Byte] = MD5.compute(bytes)
   def now =
-    SyncIO.monotonic
-      .map(d => Instant.EPOCH.plusNanos(d.toNanos))
-      .unsafeRunSync()
+    SyncIO.realTime.map(d => Instant.EPOCH.plusNanos(d.toNanos)).unsafeRunSync()
 }

--- a/project/KinesisMockPlugin.scala
+++ b/project/KinesisMockPlugin.scala
@@ -159,6 +159,10 @@ object KinesisMockPlugin extends AutoPlugin {
             "max_attempts" -> "3",
             "command" -> "sbt 'project ${{ matrix.project }}' integration-tests/test",
             "retry_on" -> "error"
+          ),
+          env = Map(
+            "CBOR_ENABLED" -> "${{ matrix.cbor_enabled }}",
+            "SERVICE_PORT" -> "${{ matrix.service_port }}"
           )
         ),
         WorkflowStep.Sbt(


### PR DESCRIPTION
## Changes Introduced

Enables Http2 support on both plain and TLS ports

## Applicable linked issues

#29 

## Checklist (check all that apply)

- [x] This change maintains backwards compatibility
- [x] I have introduced tests for all new features and changes
- [x] I have added documentation covering all new features and changes
- [x] This pull-request is ready for review